### PR TITLE
add `arb_trading`

### DIFF
--- a/arb_trading/README.md
+++ b/arb_trading/README.md
@@ -1,0 +1,94 @@
+# 차익거래 시스템 (Arbitrage Trading System)
+
+모듈화된 암호화폐 차익거래 자동화 시스템입니다.
+
+## 주요 특징
+
+- 🚀 **고성능**: 비동기 처리로 빠른 데이터 수집 및 거래 실행
+- 🔧 **모듈화**: 확장 가능한 구조로 새로운 거래소 쉽게 추가
+- 📊 **실시간 모니터링**: 스프레드 실시간 추적 및 성능 측정
+- 🛡️ **리스크 관리**: 포지션 크기 제한, 손절 기능
+- 📱 **알림 시스템**: Slack, Telegram, Email 지원
+- 🎯 **시뮬레이션**: 실거래 전 테스트 가능
+
+## 설치 방법
+
+```bash
+# 저장소 클론
+git clone https://github.com/yourusername/arb-trading.git
+cd arb-trading
+
+# 의존성 설치
+pip install -r requirements.txt
+
+# 개발 모드 설치
+pip install -e .
+```
+
+## 사용법
+
+### 1. 설정 파일 생성
+
+```bash
+python -c "from arb_trading import create_config_template; create_config_template('my_config.json')"
+```
+
+### 2. API 키 설정
+
+생성된 설정 파일에서 API 키를 입력하세요:
+
+```json
+{
+  "exchanges": {
+    "binance": {
+      "api_key": "YOUR_BINANCE_API_KEY",
+      "secret": "YOUR_BINANCE_SECRET"
+    },
+    "bybit": {
+      "api_key": "YOUR_BYBIT_API_KEY",
+      "secret": "YOUR_BYBIT_SECRET"
+    }
+  }
+}
+```
+
+### 3. 실행
+
+```bash
+# 시뮬레이션 모드
+arb-trading --simulation --config my_config.json
+
+# 실거래 모드 (주의!)
+arb-trading --config my_config.json
+
+# 성능 모니터링 활성화
+arb-trading --simulation --performance
+
+# 스프레드 임계값 설정
+arb-trading --simulation --spread-threshold 0.8
+```
+
+## 명령행 옵션
+
+- `--config, -c`: 설정 파일 경로
+- `--simulation, -s`: 시뮬레이션 모드
+- `--performance, -p`: 성능 모니터링 활성화
+- `--log-level, -l`: 로그 레벨 (DEBUG, INFO, WARNING, ERROR)
+- `--order-type`: 주문 타입 (limit, market)
+- `--max-positions`: 최대 포지션 수
+- `--spread-threshold`: 스프레드 임계값 (%)
+
+## 프로젝트 구조
+
+```
+arb_trading/
+├── config/          # 설정 관리
+├── exchanges/       # 거래소 인터페이스
+├── core/           # 핵심 로직
+├── utils/          # 유틸리티
+└── tests/          # 테스트
+```
+
+## 라이센스
+
+MIT License

--- a/arb_trading/__init__.py
+++ b/arb_trading/__init__.py
@@ -1,0 +1,161 @@
+# arb_trading/__init__.py (업데이트)
+"""
+차익거래 시스템
+
+모듈화된 암호화폐 차익거래 자동화 시스템
+- 바이낸스, 바이빗 거래소 지원
+- 실시간 스프레드 모니터링
+- 자동 포지션 관리
+- 성능 모니터링 및 알림 시스템
+
+사용법:
+    python -m arb_trading                    # 기본 실행
+    python -m arb_trading --simulation       # 시뮬레이션 모드
+    python -m arb_trading --help            # 도움말
+"""
+
+__version__ = "1.0.0"
+__author__ = "Arbitrage Team"
+
+from .config.settings import ConfigManager
+from .core.arbitrage_engine import ArbitrageEngine
+from .core.spread_monitor import SpreadMonitor
+from .core.position_manager import PositionManager
+from .exchanges.binance import BinanceExchange
+from .exchanges.bybit import BybitExchange
+
+__all__ = [
+    'ConfigManager',
+    'ArbitrageEngine',
+    'SpreadMonitor',
+    'PositionManager',
+    'BinanceExchange',
+    'BybitExchange'
+]
+
+
+# 설정 파일 템플릿 생성 함수
+def create_config_template(path: str = "config.json"):
+    """설정 파일 템플릿 생성"""
+    import json
+    from pathlib import Path
+
+    template = {
+        "trading": {
+            "simulation_mode": True,
+            "max_positions": 3,
+            "target_usdt": 100,
+            "spread_threshold": 0.5,
+            "exit_percent": 0.5,
+            "spread_hold_count": 3,
+            "top_symbol_limit": 300,
+            "min_volume_usdt": 5000000
+        },
+        "exchanges": {
+            "binance": {
+                "enabled": True,
+                "fetch_only": False,
+                "api_key": "YOUR_BINANCE_API_KEY",
+                "secret": "YOUR_BINANCE_SECRET"
+            },
+            "bybit": {
+                "enabled": True,
+                "fetch_only": True,
+                "api_key": "YOUR_BYBIT_API_KEY",
+                "secret": "YOUR_BYBIT_SECRET"
+            }
+        },
+        "orders": {
+            "default_type": "limit",
+            "market_order_enabled": False,
+            "stop_loss_enabled": False,
+            "limit_order_slippage": 0.001
+        },
+        "monitoring": {
+            "performance_logging": False,
+            "fetch_interval": 5,
+            "log_buffer_size": 100
+        },
+        "notifications": {
+            "slack_webhook": "",
+            "telegram_token": "",
+            "telegram_chat_id": "",
+            "email_smtp": "",
+            "email_user": "",
+            "email_password": ""
+        },
+        "risk_management": {
+            "max_loss_percent": -10,
+            "position_timeout_seconds": 300,
+            "order_timeout_seconds": 60
+        }
+    }
+
+    config_path = Path(path)
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with open(config_path, 'w', encoding='utf-8') as f:
+        json.dump(template, f, indent=4, ensure_ascii=False)
+
+    print(f"✅ 설정 파일 템플릿 생성: {path}")
+    print(f"📝 API 키를 입력하고 설정을 수정한 후 사용하세요.")
+    print(f"🚀 실행: python -m arb_trading --config {path}")
+
+
+# 빠른 시작 가이드 표시 함수
+def show_quick_start():
+    """빠른 시작 가이드 표시"""
+    print("""
+🚀 차익거래 시스템 빠른 시작 가이드
+
+1️⃣ 설정 파일 생성:
+   python -m arb_trading --create-config my_config.json
+
+2️⃣ API 키 설정:
+   my_config.json 파일을 열어서 API 키 입력
+
+3️⃣ 시뮬레이션 실행:
+   python -m arb_trading --config my_config.json --simulation
+
+4️⃣ 성능 모니터링:
+   python -m arb_trading --simulation --performance
+
+5️⃣ 실거래 (주의!):
+   python -m arb_trading --config my_config.json
+
+📚 도움말: python -m arb_trading --help
+🐛 디버그: python -m arb_trading --simulation --log-level DEBUG
+""")
+
+
+# 사용 예시 및 도움말
+USAGE_EXAMPLES = """
+📖 사용 예시:
+
+기본 사용법:
+  python -m arb_trading                                 # 기본 설정으로 실행
+  python -m arb_trading --simulation                    # 시뮬레이션 모드
+  python -m arb_trading --help                         # 도움말 표시
+
+설정 관리:
+  python -m arb_trading --create-config config.json    # 설정 파일 생성
+  python -m arb_trading --config my_config.json        # 커스텀 설정 사용
+
+성능 및 디버깅:
+  python -m arb_trading --performance                   # 성능 모니터링
+  python -m arb_trading --log-level DEBUG              # 디버그 로그
+  python -m arb_trading --performance --log-level DEBUG # 상세 모니터링
+
+파라미터 조정:
+  python -m arb_trading --spread-threshold 0.3         # 스프레드 임계값 0.3%
+  python -m arb_trading --max-positions 5              # 최대 5개 포지션
+  python -m arb_trading --fetch-interval 3             # 3초 간격 조회
+
+조합 사용:
+  python -m arb_trading \\
+    --config my_config.json \\
+    --simulation \\
+    --performance \\
+    --spread-threshold 0.2 \\
+    --log-level INFO
+"""

--- a/arb_trading/__init__.py
+++ b/arb_trading/__init__.py
@@ -42,7 +42,7 @@ def create_config_template(path: str = "config.json"):
 
     template = {
         "trading": {
-            "simulation_mode": True,
+            "simulation_mode": False,
             "max_positions": 3,
             "target_usdt": 100,
             "spread_threshold": 0.5,

--- a/arb_trading/__main__.py
+++ b/arb_trading/__main__.py
@@ -1,0 +1,241 @@
+# arb_trading/__main__.py (경로 및 import 수정)
+import asyncio
+import argparse
+import sys
+import signal
+from pathlib import Path
+from arb_trading.config.settings import ConfigManager
+from arb_trading.core.arbitrage_engine import ArbitrageEngine
+from arb_trading.utils.logger import setup_logger
+from arb_trading.utils.platform_utils import setup_windows_event_loop
+
+
+def parse_arguments():
+    """명령행 인수 파싱"""
+    parser = argparse.ArgumentParser(
+        description='암호화폐 차익거래 자동화 시스템',
+        epilog="""
+사용 예시:
+  python -m arb_trading --simulation                    # 시뮬레이션 모드
+  python -m arb_trading --performance --log-level DEBUG # 디버그 + 성능 모니터링
+  python -m arb_trading --config custom.json           # 커스텀 설정 파일
+  python -m arb_trading --spread-threshold 0.3         # 스프레드 임계값 0.3%
+        """,
+        formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+
+    parser.add_argument(
+        '--config', '-c',
+        type=str,
+        default=None,
+        metavar='FILE',
+        help='설정 파일 경로 (기본: config/default_config.json)'
+    )
+
+    parser.add_argument(
+        '--simulation', '-s',
+        action='store_true',
+        help='시뮬레이션 모드로 실행 (실제 거래 안함)'
+    )
+
+    parser.add_argument(
+        '--performance', '-p',
+        action='store_true',
+        help='성능 모니터링 활성화 (상세 로깅)'
+    )
+
+    parser.add_argument(
+        '--log-level', '-l',
+        type=str,
+        default='INFO',
+        choices=['DEBUG', 'INFO', 'WARNING', 'ERROR'],
+        help='로그 레벨 설정 (기본: INFO)'
+    )
+
+    parser.add_argument(
+        '--log-file',
+        type=str,
+        default='logs/arbitrage.log',
+        metavar='FILE',
+        help='로그 파일 경로 (기본: logs/arbitrage.log)'
+    )
+
+    parser.add_argument(
+        '--order-type',
+        type=str,
+        default='limit',
+        choices=['limit', 'market'],
+        help='기본 주문 타입 (기본: limit)'
+    )
+
+    parser.add_argument(
+        '--max-positions',
+        type=int,
+        default=None,
+        metavar='N',
+        help='최대 포지션 수 (기본: 3)'
+    )
+
+    parser.add_argument(
+        '--spread-threshold',
+        type=float,
+        default=None,
+        metavar='PCT',
+        help='스프레드 임계값 %% (기본: 0.5)'
+    )
+
+    parser.add_argument(
+        '--fetch-interval',
+        type=int,
+        default=None,
+        metavar='SEC',
+        help='데이터 조회 간격 초 (기본: 5)'
+    )
+
+    parser.add_argument(
+        '--create-config',
+        type=str,
+        metavar='FILE',
+        help='설정 파일 템플릿 생성 후 종료'
+    )
+
+    parser.add_argument(
+        '--version', '-v',
+        action='version',
+        version='차익거래 시스템 v1.0.0'
+    )
+
+    return parser.parse_args()
+
+
+async def main():
+    """메인 함수"""
+    # Windows 환경 설정
+    setup_windows_event_loop()
+
+    args = parse_arguments()
+
+    # 설정 파일 생성 요청 처리
+    if args.create_config:
+        from . import create_config_template
+        create_config_template(args.create_config)
+        return
+
+    # 로거 설정
+    logger = setup_logger(
+        name="main",
+        log_file=args.log_file,
+        level=args.log_level
+    )
+
+    engine = None
+
+    try:
+        logger.info("=" * 60)
+        logger.info("🚀 차익거래 시스템 시작")
+        logger.info(f"📁 작업 디렉토리: {Path.cwd()}")
+        logger.info(f"🐍 Python 버전: {sys.version.split()[0]}")
+        logger.info(f"💻 플랫폼: {sys.platform}")
+        logger.info("=" * 60)
+
+        # 설정 로드
+        try:
+            config_manager = ConfigManager(args.config)
+            logger.info(f"✅ 설정 파일 로드 완료: {config_manager.config_path}")
+        except Exception as e:
+            logger.error(f"❌ 설정 파일 로드 실패: {e}")
+            logger.info("💡 설정 파일 생성: python -m arb_trading --create-config config.json")
+            return
+
+        # 명령행 인수로 설정 덮어쓰기
+        config_updates = []
+
+        if args.simulation:
+            config_manager.update_config('trading', 'simulation_mode', True)
+            config_updates.append("시뮬레이션 모드")
+
+        if args.performance:
+            config_manager.update_config('monitoring', 'performance_logging', True)
+            config_updates.append("성능 모니터링")
+
+        if args.order_type:
+            config_manager.update_config('orders', 'default_type', args.order_type)
+            config_updates.append(f"주문 타입: {args.order_type}")
+
+        if args.max_positions:
+            config_manager.update_config('trading', 'max_positions', args.max_positions)
+            config_updates.append(f"최대 포지션: {args.max_positions}")
+
+        if args.spread_threshold:
+            config_manager.update_config('trading', 'spread_threshold', args.spread_threshold)
+            config_updates.append(f"스프레드 임계값: {args.spread_threshold}%")
+
+        if args.fetch_interval:
+            config_manager.update_config('monitoring', 'fetch_interval', args.fetch_interval)
+            config_updates.append(f"조회 간격: {args.fetch_interval}초")
+
+        if config_updates:
+            logger.info(f"⚙️ 설정 업데이트: {', '.join(config_updates)}")
+
+        # 현재 설정 요약 표시
+        trading_config = config_manager.trading
+        monitoring_config = config_manager.monitoring
+
+        logger.info("📋 현재 설정:")
+        logger.info(f"   모드: {'🔍 시뮬레이션' if trading_config.simulation_mode else '💰 실거래'}")
+        logger.info(f"   스프레드 임계값: {trading_config.spread_threshold}%")
+        logger.info(f"   최대 포지션: {trading_config.max_positions}개")
+        logger.info(f"   조회 간격: {monitoring_config.fetch_interval}초")
+        logger.info(f"   성능 모니터링: {'✅' if monitoring_config.performance_logging else '❌'}")
+
+        # 거래소 설정 표시
+        exchanges_config = config_manager.exchanges
+        logger.info("🏪 거래소 설정:")
+        for name, config in exchanges_config.items():
+            if config.enabled:
+                mode = "📊 데이터만" if config.fetch_only else "💸 거래가능"
+                api_status = "🔑 API키 설정됨" if config.api_key else "🔓 API키 없음"
+                logger.info(f"   {name.upper()}: {mode} ({api_status})")
+
+        # 엔진 생성 및 실행
+        engine = ArbitrageEngine(config_manager)
+        await engine.run()
+
+    except KeyboardInterrupt:
+        logger.info("⏹️ 사용자에 의한 종료 요청")
+    except Exception as e:
+        logger.error(f"💥 예상치 못한 오류: {e}")
+        import traceback
+        logger.debug(traceback.format_exc())
+        sys.exit(1)
+    finally:
+        if engine:
+            await engine.cleanup()
+        logger.info("🏁 프로그램 종료")
+
+
+def run():
+    """동기 실행 래퍼"""
+    # Windows 환경 설정
+    setup_windows_event_loop()
+
+    # 기본 시그널 핸들러 설정
+    def signal_handler(signum, frame):
+        print(f"\n⏹️ 종료 신호 수신: {signum}")
+        sys.exit(0)
+
+    signal.signal(signal.SIGINT, signal_handler)
+    signal.signal(signal.SIGTERM, signal_handler)
+
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        print("\n🏁 프로그램이 종료되었습니다.")
+    except Exception as e:
+        print(f"💥 실행 중 오류 발생: {e}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    run()
+

--- a/arb_trading/config/__init__.py
+++ b/arb_trading/config/__init__.py
@@ -1,0 +1,22 @@
+# arb_trading/config/__init__.py
+"""설정 모듈"""
+
+from .settings import (
+    ConfigManager,
+    TradingConfig,
+    ExchangeConfig,
+    OrderConfig,
+    MonitoringConfig,
+    NotificationConfig,
+    RiskConfig
+)
+
+__all__ = [
+    'ConfigManager',
+    'TradingConfig',
+    'ExchangeConfig',
+    'OrderConfig',
+    'MonitoringConfig',
+    'NotificationConfig',
+    'RiskConfig'
+]

--- a/arb_trading/config/default_config.json
+++ b/arb_trading/config/default_config.json
@@ -1,6 +1,6 @@
 {
     "trading": {
-        "simulation_mode": true,
+        "simulation_mode": false,
         "max_positions": 3,
         "target_usdt": 100,
         "spread_threshold": 1.2,

--- a/arb_trading/config/default_config.json
+++ b/arb_trading/config/default_config.json
@@ -1,0 +1,50 @@
+{
+    "trading": {
+        "simulation_mode": true,
+        "max_positions": 3,
+        "target_usdt": 100,
+        "spread_threshold": 1.2,
+        "exit_percent": 1.2,
+        "spread_hold_count": 3,
+        "top_symbol_limit": 300,
+        "min_volume_usdt": 5000000
+    },
+    "exchanges": {
+        "binance": {
+            "enabled": true,
+            "fetch_only": false,
+            "api_key": "",
+            "secret": ""
+        },
+        "bybit": {
+            "enabled": true,
+            "fetch_only": false,
+            "api_key": "",
+            "secret": ""
+        }
+    },
+    "orders": {
+        "default_type": "limit",
+        "market_order_enabled": false,
+        "stop_loss_enabled": false,
+        "limit_order_slippage": 0.001
+    },
+    "monitoring": {
+        "performance_logging": true,
+        "fetch_interval": 5,
+        "log_buffer_size": 100
+    },
+    "notifications": {
+        "slack_webhook": "",
+        "telegram_token": "",
+        "telegram_chat_id": "",
+        "email_smtp": "",
+        "email_user": "",
+        "email_password": ""
+    },
+    "risk_management": {
+        "max_loss_percent": -10,
+        "position_timeout_seconds": 300,
+        "order_timeout_seconds": 60
+    }
+}

--- a/arb_trading/config/settings.py
+++ b/arb_trading/config/settings.py
@@ -1,0 +1,126 @@
+# arb_trading/config/settings.py
+import json
+import os
+from typing import Dict, Any
+from dataclasses import dataclass
+from pathlib import Path
+from dotenv import load_dotenv
+
+
+@dataclass
+class TradingConfig:
+    simulation_mode: bool
+    max_positions: int
+    target_usdt: float
+    spread_threshold: float
+    exit_percent: float
+    spread_hold_count: int
+    top_symbol_limit: int
+    min_volume_usdt: int
+
+
+@dataclass
+class ExchangeConfig:
+    enabled: bool
+    fetch_only: bool
+    api_key: str
+    secret: str
+
+
+@dataclass
+class OrderConfig:
+    default_type: str
+    market_order_enabled: bool
+    stop_loss_enabled: bool
+    limit_order_slippage: float
+
+
+@dataclass
+class MonitoringConfig:
+    performance_logging: bool
+    fetch_interval: int
+    log_buffer_size: int
+
+
+@dataclass
+class NotificationConfig:
+    slack_webhook: str
+    telegram_token: str
+    telegram_chat_id: str
+    email_smtp: str
+    email_user: str
+    email_password: str
+
+
+@dataclass
+class RiskConfig:
+    max_loss_percent: float
+    position_timeout_seconds: int
+    order_timeout_seconds: int
+
+
+class ConfigManager:
+    def __init__(self, config_path: str = None):
+        self.config_path = config_path or self._get_default_config_path()
+        self._config = self._load_config()
+
+    def _get_default_config_path(self) -> str:
+        return str(Path(__file__).parent / "default_config.json")
+
+    def _load_config(self) -> Dict[str, Any]:
+        load_dotenv()
+        try:
+            with open(self.config_path, 'r', encoding='utf-8') as f:
+                config = json.load(f)
+
+            # 환경변수에서 API 키 덮어쓰기
+            if 'BINANCE_API_KEY' in os.environ:
+                config['exchanges']['binance']['api_key'] = os.environ['BINANCE_API_KEY']
+            if 'BINANCE_SECRET' in os.environ:
+                config['exchanges']['binance']['secret'] = os.environ['BINANCE_SECRET']
+            if 'BYBIT_API_KEY' in os.environ:
+                config['exchanges']['bybit']['api_key'] = os.environ['BYBIT_API_KEY']
+            if 'BYBIT_SECRET' in os.environ:
+                config['exchanges']['bybit']['secret'] = os.environ['BYBIT_SECRET']
+
+            return config
+        except Exception as e:
+            raise Exception(f"설정 파일 로드 실패: {e}")
+
+    @property
+    def trading(self) -> TradingConfig:
+        return TradingConfig(**self._config['trading'])
+
+    @property
+    def exchanges(self) -> Dict[str, ExchangeConfig]:
+        return {
+            name: ExchangeConfig(**config)
+            for name, config in self._config['exchanges'].items()
+        }
+
+    @property
+    def orders(self) -> OrderConfig:
+        return OrderConfig(**self._config['orders'])
+
+    @property
+    def monitoring(self) -> MonitoringConfig:
+        return MonitoringConfig(**self._config['monitoring'])
+
+    @property
+    def notifications(self) -> NotificationConfig:
+        return NotificationConfig(**self._config['notifications'])
+
+    @property
+    def risk(self) -> RiskConfig:
+        return RiskConfig(**self._config['risk_management'])
+
+    def update_config(self, section: str, key: str, value: Any):
+        """설정 값 동적 업데이트"""
+        if section in self._config and key in self._config[section]:
+            self._config[section][key] = value
+
+    def save_config(self, path: str = None):
+        """설정을 파일로 저장"""
+        save_path = path or self.config_path
+        with open(save_path, 'w', encoding='utf-8') as f:
+            json.dump(self._config, f, indent=4, ensure_ascii=False)

--- a/arb_trading/core/__init__.py
+++ b/arb_trading/core/__init__.py
@@ -1,0 +1,19 @@
+# arb_trading/core/__init__.py
+"""핵심 모듈"""
+
+from .arbitrage_engine import ArbitrageEngine
+from .spread_monitor import SpreadMonitor, SpreadData
+from .position_manager import PositionManager, ArbitragePosition, PositionStatus
+from .order_manager import OrderManager, ManagedOrder, OrderStatus
+
+__all__ = [
+    'ArbitrageEngine',
+    'SpreadMonitor',
+    'SpreadData',
+    'PositionManager',
+    'ArbitragePosition',
+    'PositionStatus',
+    'OrderManager',
+    'ManagedOrder',
+    'OrderStatus'
+]

--- a/arb_trading/core/arbitrage_engine.py
+++ b/arb_trading/core/arbitrage_engine.py
@@ -1,0 +1,509 @@
+# arb_trading/core/arbitrage_engine.py (종료 처리 수정)
+import asyncio
+import time
+import signal
+import sys
+from typing import Dict, List, Optional
+from collections import defaultdict, deque
+from ..exchanges.base import BaseExchange, OrderType, OrderSide, Direction
+from ..config.settings import ConfigManager, TradingConfig, OrderConfig, RiskConfig
+from .spread_monitor import SpreadMonitor, SpreadData
+from .position_manager import PositionManager, ArbitragePosition, PositionStatus
+from ..utils.performance import PerformanceMonitor
+from ..utils.notifications import NotificationManager
+from ..utils.logger import setup_logger
+import logging
+import traceback
+
+
+class ArbitrageEngine:
+    """차익거래 엔진 메인 클래스"""
+
+    def __init__(self, config_manager: ConfigManager):
+        self.config = config_manager
+        self.logger = setup_logger("arbitrage_engine",
+                                   level="INFO",
+                                   log_file="logs/arbitrage.log")
+
+        # 설정 로드
+        self.trading_config = config_manager.trading
+        self.order_config = config_manager.orders
+        self.risk_config = config_manager.risk
+
+        # 컴포넌트 초기화
+        self.exchanges: Dict[str, BaseExchange] = {}
+        self.spread_monitor: Optional[SpreadMonitor] = None
+        self.position_manager: Optional[PositionManager] = None
+        self.performance_monitor: Optional[PerformanceMonitor] = None
+        self.notification_manager: Optional[NotificationManager] = None
+
+        # 상태 관리
+        self.is_running = False
+        self.shutdown_event = asyncio.Event()
+        self._shutdown_requested = False
+
+        # 스프레드 히스토리 (진입 조건 판단용)
+        self.spread_history = defaultdict(lambda: deque(maxlen=self.trading_config.spread_hold_count))
+        self.top1_history = defaultdict(lambda: deque(maxlen=self.trading_config.spread_hold_count))
+        self.exit_condition_history = defaultdict(lambda: deque(maxlen=self.trading_config.spread_hold_count))
+
+        # 로그 버퍼
+        self.log_buffer = []
+        self.log_buffer_size = config_manager.monitoring.log_buffer_size
+
+        # 시그널 핸들러 등록
+        self._setup_signal_handlers()
+
+    def _setup_signal_handlers(self):
+        """시그널 핸들러 설정"""
+
+        def signal_handler(signum, frame):
+            self.logger.info(f"종료 신호 수신: {signum}")
+            self._shutdown_requested = True
+            self.shutdown_event.set()
+
+            # 즉시 종료를 위한 추가 처리
+            if not self.is_running:
+                sys.exit(0)
+
+        try:
+            signal.signal(signal.SIGINT, signal_handler)
+            signal.signal(signal.SIGTERM, signal_handler)
+            self.logger.debug("시그널 핸들러 등록 성공")
+        except Exception as e:
+            self.logger.warning(f"시그널 핸들러 등록 실패: {e}")
+
+    async def initialize(self):
+        """엔진 초기화"""
+        try:
+            # 성능 모니터 초기화
+            try:
+                self.performance_monitor = PerformanceMonitor(
+                    enabled=self.config.monitoring.performance_logging
+                )
+            except Exception as e:
+                self.logger.error(f"❌ 성능 모니터 초기화 실패: {e}")
+                raise
+
+            # 알림 관리자 초기화
+            try:
+                notification_config = self.config.notifications
+                self.notification_manager = NotificationManager(
+                    slack_webhook=notification_config.slack_webhook,
+                    telegram_token=notification_config.telegram_token,
+                    telegram_chat_id=notification_config.telegram_chat_id,
+                    email_config={
+                        'smtp_server': notification_config.email_smtp,
+                        'user': notification_config.email_user,
+                        'password': notification_config.email_password
+                    } if notification_config.email_smtp else {}
+                )
+            except Exception as e:
+                self.logger.error(f"❌ 알림 관리자 초기화 실패: {e}")
+                raise
+
+            # 거래소 초기화
+            try:
+                await self._initialize_exchanges()
+            except Exception as e:
+                self.logger.error(f"❌ 거래소 초기화 실패: {e}")
+                raise
+
+            # 스프레드 모니터 초기화
+            try:
+                self.spread_monitor = SpreadMonitor(
+                    exchanges=self.exchanges,
+                    min_volume_usdt=self.trading_config.min_volume_usdt,
+                    top_symbol_limit=self.trading_config.top_symbol_limit,
+                    performance_monitor=self.performance_monitor
+                )
+            except Exception as e:
+                self.logger.error(f"❌ 스프레드 모니터 초기화 실패: {e}")
+                raise
+
+            # 포지션 관리자 초기화
+            try:
+                self.position_manager = PositionManager(
+                    max_positions=self.trading_config.max_positions,
+                    position_timeout=self.risk_config.position_timeout_seconds,
+                    order_timeout=self.risk_config.order_timeout_seconds,
+                    notification_manager=self.notification_manager
+                )
+            except Exception as e:
+                self.logger.error(f"❌ 포지션 관리자 초기화 실패: {e}")
+                raise
+
+            # self.logger.info("✅ 차익거래 엔진 초기화 완료")
+
+        except Exception as e:
+            self.logger.error(f"❌ 엔진 초기화 실패: {e}")
+            self.logger.error(f"상세 오류: {traceback.format_exc()}")
+            raise
+
+    async def _initialize_exchanges(self):
+        """거래소 초기화"""
+        try:
+            from ..exchanges.binance import BinanceExchange
+            from ..exchanges.bybit import BybitExchange
+        except Exception as e:
+            self.logger.error(f"❌ 거래소 모듈 임포트 실패: {e}")
+            raise
+
+        exchange_configs = self.config.exchanges
+        # self.logger.info(f"설정된 거래소: {list(exchange_configs.keys())}")
+
+        for exchange_name, config in exchange_configs.items():
+
+            if not config.enabled:
+                self.logger.info(f"   거래소 '{exchange_name}' 비활성화됨, 건너뜀")
+                continue
+
+            try:
+                if exchange_name == 'binance':
+                    exchange = BinanceExchange(
+                        api_key=config.api_key,
+                        secret=config.secret
+                    )
+                elif exchange_name == 'bybit':
+                    exchange = BybitExchange(
+                        api_key=config.api_key,
+                        secret=config.secret
+                    )
+                else:
+                    self.logger.warning(f"지원하지 않는 거래소: {exchange_name}")
+                    continue
+
+                # 연결 테스트
+                await exchange.connect()
+
+                self.exchanges[exchange_name] = exchange
+
+            except Exception as e:
+                self.logger.error(f"❌ '{exchange_name}' 거래소 초기화 실패: {e}")
+                self.logger.error(f"상세 오류: {traceback.format_exc()}")
+                # 거래소 초기화 실패는 치명적이므로 중단하지 않고 계속 진행
+
+        if len(self.exchanges) < 2:
+            error_msg = f"최소 2개의 거래소가 필요합니다 (현재: {len(self.exchanges)}개)"
+            self.logger.error(error_msg)
+            raise Exception(error_msg)
+
+        # self.logger.info(f"✅ 총 {len(self.exchanges)}개 거래소 초기화 완료: {list(self.exchanges.keys())}")
+
+    async def run(self):
+        """엔진 실행"""
+        try:
+            # self.logger.info("✅ 차익거래 엔진 실행 단계 시작...")
+
+            # 초기화
+            await self.initialize()
+            self.is_running = True
+            # self.logger.info("✅ initialize() 완료, is_running = True")
+
+            self.logger.info(f"🔄 차익거래 모니터링 시작 ({self.config.monitoring.fetch_interval}초 간격)")
+
+            # 초기 스프레드 데이터 조회 테스트
+            # self.logger.info("📊 초기 스프레드 데이터 조회 테스트 중...")
+            try:
+                initial_spreads = await self.spread_monitor.fetch_spread_data()
+                self.logger.info(f"✅ 초기 스프레드 데이터 조회 성공: {len(initial_spreads)}개 심볼")
+
+            except Exception as e:
+                self.logger.error(f"❌ 초기 스프레드 데이터 조회 실패: {e}")
+                import traceback
+                self.logger.error(f"상세 오류: {traceback.format_exc()}")
+                raise
+
+            # 메인 루프 시작
+            self.logger.info("🚀 메인 모니터링 루프 시작...")
+            loop_count = 0
+
+            while self.is_running and not self.shutdown_event.is_set():
+                try:
+                    self.logger.debug(f"루프 {loop_count + 1} 시작...")
+
+                    # 종료 요청 확인
+                    if self._shutdown_requested:
+                        self.logger.info("종료 요청 감지됨")
+                        break
+
+                    loop_start_time = time.time()
+
+                    # 스프레드 데이터 조회
+                    self.logger.debug("스프레드 데이터 조회 중...")
+                    spread_data = await self.spread_monitor.fetch_spread_data()
+
+                    if not spread_data:
+                        self.logger.warning("스프레드 데이터를 조회할 수 없습니다")
+                        await asyncio.sleep(self.config.monitoring.fetch_interval)
+                        continue
+
+                    # 상위 3개 스프레드 표시
+                    await self._display_top_spreads(spread_data[:3])
+
+                    # Top1 기록 업데이트
+                    self._update_top1_history(spread_data)
+
+                    # 포지션 상태 업데이트
+                    await self._update_positions()
+
+                    # 진입 조건 확인
+                    await self._check_entry_conditions(spread_data)
+
+                    # 청산 조건 확인
+                    await self._check_exit_conditions(spread_data)
+
+                    # 로그 버퍼 플러시
+                    loop_count += 1
+                    if loop_count % 3 == 0:
+                        await self._flush_logs()
+
+                    # 성능 정보 표시
+                    if self.performance_monitor and self.performance_monitor.enabled:
+                        if loop_count % 10 == 0:  # 10회마다 표시
+                            perf_summary = self.performance_monitor.get_performance_summary()
+                            self.logger.info(f"📈 성능 정보: {perf_summary}")
+
+                    # 대기 (종료 신호 확인과 함께)
+                    loop_duration = time.time() - loop_start_time
+                    sleep_time = max(0, self.config.monitoring.fetch_interval - loop_duration)
+
+                    self.logger.debug(f"루프 {loop_count} 완료 (소요: {loop_duration:.3f}초, 대기: {sleep_time:.3f}초)")
+
+                    if sleep_time > 0:
+                        try:
+                            await asyncio.wait_for(self.shutdown_event.wait(), timeout=sleep_time)
+                            self.logger.info("종료 신호를 받아 루프 종료")
+                            break  # 종료 신호 받음
+                        except asyncio.TimeoutError:
+                            pass  # 정상적인 타임아웃, 계속 진행
+
+                except KeyboardInterrupt:
+                    self.logger.info("KeyboardInterrupt 감지")
+                    break
+                except Exception as e:
+                    self.logger.error(f"❌ 메인 루프 오류: {e}")
+                    import traceback
+                    self.logger.error(f"상세 오류: {traceback.format_exc()}")
+
+                    if self.performance_monitor:
+                        self.performance_monitor.record_error("main_loop_error")
+
+                    await asyncio.sleep(5)  # 오류 시 5초 대기
+
+            self.logger.info("메인 루프 종료됨")
+
+        except KeyboardInterrupt:
+            self.logger.info("사용자 중단 요청")
+        except Exception as e:
+            self.logger.error(f"❌ 엔진 실행 중 치명적 오류: {e}")
+            import traceback
+            self.logger.error(f"상세 오류: {traceback.format_exc()}")
+            raise
+        finally:
+            self.logger.info("🛑 엔진 종료 처리 시작...")
+            await self.shutdown()
+
+    async def _display_top_spreads(self, top_spreads: List[SpreadData]):
+        """상위 스프레드 표시"""
+        try:
+            if top_spreads:
+                spreads_text = " | ".join([
+                    f"{item.symbol} ({item.spread_pct:+.2f}%)"
+                    for item in top_spreads
+                ])
+                self.logger.info(f"🔝 Top 3 스프레드: {spreads_text}")
+            else:
+                self.logger.warning(f"표시할 스프레드 데이터가 없습니다")
+        except Exception as e:
+            self.logger.error(f"❌ 스프레드 표시 중 오류: {e}")
+
+    def _update_top1_history(self, spread_data: List[SpreadData]):
+        """Top1 히스토리 업데이트"""
+        try:
+            if spread_data:
+                top1_symbol = spread_data[0].symbol
+                self.top1_history[top1_symbol].append(True)
+
+                # 나머지 심볼들은 False
+                for item in spread_data[1:4]:  # 상위 4개 정도만 체크
+                    self.top1_history[item.symbol].append(False)
+        except Exception as e:
+            self.logger.error(f"❌ Top1 히스토리 업데이트 중 오류: {e}")
+
+    async def _update_positions(self):
+        """포지션 상태 업데이트"""
+        try:
+            if not self.position_manager:
+                return
+
+            pending_symbols = [
+                symbol for symbol, pos in self.position_manager.positions.items()
+                if pos.status == PositionStatus.PENDING
+            ]
+
+            for symbol in pending_symbols:
+                await self.position_manager.update_position_status(symbol)
+        except Exception as e:
+            self.logger.error(f"❌ 포지션 업데이트 중 오류: {e}")
+
+    async def _check_entry_conditions(self, spread_data: List[SpreadData]):
+        """진입 조건 확인"""
+        try:
+            if not self.position_manager or not self.position_manager.can_open_position():
+                return
+
+            # 스프레드 임계값 이상인 항목들만 필터링
+            filtered_spreads = [
+                item for item in spread_data
+                if item.abs_spread_pct >= self.trading_config.spread_threshold
+            ]
+
+            if filtered_spreads:
+                self.logger.debug(f"임계값 이상 스프레드: {len(filtered_spreads)}개")
+
+            for spread_item in filtered_spreads:
+                symbol = spread_item.symbol
+
+                # 이미 포지션이 있는 경우 건너뛰기
+                if symbol in self.position_manager.positions:
+                    continue
+
+                # 스프레드 히스토리 업데이트
+                self.spread_history[symbol].append(spread_item.spread_pct)
+
+                # 진입 조건 확인
+                if self._should_enter_position(symbol, spread_item):
+                    self.logger.info(f"🟢 조건 충족: {symbol} → 시뮬레이션 진입")
+        except Exception as e:
+            self.logger.error(f"❌ 진입 조건 확인 중 오류: {e}")
+
+    def _should_enter_position(self, symbol: str, spread_data: SpreadData) -> bool:
+        """포지션 진입 조건 확인"""
+        try:
+            # 스프레드 지속 조건
+            spread_hist = self.spread_history[symbol]
+            if len(spread_hist) < self.trading_config.spread_hold_count:
+                return False
+
+            # 모든 히스토리가 임계값 이상인지 확인
+            if not all(abs(s) >= self.trading_config.spread_threshold for s in spread_hist):
+                return False
+
+            # Top1 지속 조건
+            top1_hist = self.top1_history[symbol]
+            if len(top1_hist) < self.trading_config.spread_hold_count:
+                return False
+
+            if not all(top1_hist):
+                return False
+
+            return True
+        except Exception as e:
+            self.logger.error(f"❌ 진입 조건 확인 중 오류 ({symbol}): {e}")
+            return False
+
+    async def _check_exit_conditions(self, spread_data: List[SpreadData]):
+        """청산 조건 확인 (시뮬레이션용)"""
+        try:
+            # 시뮬레이션에서는 실제 포지션이 없으므로 간단히 처리
+            pass
+        except Exception as e:
+            self.logger.error(f"❌ 청산 조건 확인 중 오류: {e}")
+
+    async def _flush_logs(self):
+        """로그 버퍼 플러시"""
+        try:
+            if self.log_buffer:
+                self.log_buffer.clear()
+        except Exception as e:
+            self.logger.error(f"❌ 로그 플러시 중 오류: {e}")
+
+    async def shutdown(self):
+        """시스템 종료"""
+        try:
+            if not self.is_running:
+                return
+
+            self.logger.info("차익거래 시스템 종료 시작...")
+            self.is_running = False
+
+            # 모든 포지션 청산 (시뮬레이션에서는 생략)
+            if self.position_manager and not self.trading_config.simulation_mode:
+                await self.position_manager.close_all_positions("시스템 종료")
+
+            await self.cleanup()
+        except Exception as e:
+            self.logger.error(f"❌ 시스템 종료 중 오류: {e}")
+
+    async def cleanup(self):
+        """리소스 정리"""
+        try:
+            # 거래소 연결 해제
+            cleanup_tasks = []
+            for exchange in self.exchanges.values():
+                cleanup_tasks.append(exchange.disconnect())
+
+            if cleanup_tasks:
+                await asyncio.gather(*cleanup_tasks, return_exceptions=True)
+
+            # 성능 모니터 정리
+            if self.performance_monitor:
+                self.performance_monitor.stop_monitoring()
+
+            self.logger.info("리소스 정리 완료")
+
+        except Exception as e:
+            self.logger.error(f"리소스 정리 중 오류: {e}")
+
+
+# 디버깅용 최소 테스트 함수 추가
+async def test_spread_monitor_only():
+    """스프레드 모니터만 단독 테스트"""
+    import logging
+
+    logging.basicConfig(level=logging.DEBUG)
+    logger = logging.getLogger("test")
+
+    try:
+        logger.info("1. 거래소 객체 생성...")
+        from arb_trading.exchanges.binance import BinanceExchange
+        from arb_trading.exchanges.bybit import BybitExchange
+
+        binance = BinanceExchange()
+        bybit = BybitExchange()
+        exchanges = {"binance": binance, "bybit": bybit}
+        logger.info("✅ 거래소 객체 생성 완료")
+
+        logger.info("2. 거래소 연결...")
+        await binance.connect()
+        await bybit.connect()
+        logger.info("✅ 거래소 연결 완료")
+
+        logger.info("3. 스프레드 모니터 생성...")
+        from arb_trading.core.spread_monitor import SpreadMonitor
+        monitor = SpreadMonitor(exchanges=exchanges)
+        logger.info("✅ 스프레드 모니터 생성 완료")
+
+        logger.info("4. 스프레드 데이터 조회...")
+        spreads = await monitor.fetch_spread_data()
+        logger.info(f"✅ 스프레드 데이터 조회 완료: {len(spreads)}개")
+
+        if spreads:
+            logger.info(f"상위 3개: {spreads[:3]}")
+
+        logger.info("5. 연결 해제...")
+        await binance.disconnect()
+        await bybit.disconnect()
+        logger.info("✅ 테스트 완료")
+
+    except Exception as e:
+        logger.error(f"❌ 테스트 실패: {e}")
+        import traceback
+        logger.error(traceback.format_exc())
+
+
+if __name__ == "__main__":
+    import asyncio
+
+    asyncio.run(test_spread_monitor_only())

--- a/arb_trading/core/order_manager.py
+++ b/arb_trading/core/order_manager.py
@@ -1,0 +1,144 @@
+# arb_trading/core/order_manager.py
+import asyncio
+import time
+from typing import Dict, List, Optional, Tuple
+from dataclasses import dataclass
+from enum import Enum
+from ..exchanges.base import BaseExchange, Order, OrderType, OrderSide
+import logging
+
+
+class OrderStatus(Enum):
+    PENDING = "pending"
+    FILLED = "filled"
+    CANCELLED = "cancelled"
+    TIMEOUT = "timeout"
+
+
+@dataclass
+class ManagedOrder:
+    """관리되는 주문"""
+    order: Order
+    exchange: BaseExchange
+    created_at: float
+    timeout: int = 60
+    status: OrderStatus = OrderStatus.PENDING
+
+
+class OrderManager:
+    """주문 관리 클래스"""
+
+    def __init__(self, default_timeout: int = 60):
+        self.default_timeout = default_timeout
+        self.managed_orders: Dict[str, ManagedOrder] = {}
+        self.logger = logging.getLogger(__name__)
+
+    def add_order(self, order: Order, exchange: BaseExchange, timeout: Optional[int] = None) -> str:
+        """주문 추가"""
+        managed_order = ManagedOrder(
+            order=order,
+            exchange=exchange,
+            created_at=time.time(),
+            timeout=timeout or self.default_timeout
+        )
+
+        order_key = f"{exchange.name}_{order.id}"
+        self.managed_orders[order_key] = managed_order
+
+        self.logger.info(f"주문 관리 시작: {order_key}")
+        return order_key
+
+    async def check_order_status(self, order_key: str) -> OrderStatus:
+        """주문 상태 확인"""
+        if order_key not in self.managed_orders:
+            return OrderStatus.CANCELLED
+
+        managed_order = self.managed_orders[order_key]
+
+        try:
+            # 타임아웃 체크
+            if time.time() - managed_order.created_at > managed_order.timeout:
+                await self._handle_timeout_order(order_key, managed_order)
+                return OrderStatus.TIMEOUT
+
+            # 주문 상태 조회
+            updated_order = await managed_order.exchange.fetch_order(
+                managed_order.order.id,
+                managed_order.order.symbol
+            )
+
+            managed_order.order = updated_order
+
+            if updated_order.filled > 0:
+                managed_order.status = OrderStatus.FILLED
+                self.logger.info(f"주문 체결 완료: {order_key} - {updated_order.filled}")
+                return OrderStatus.FILLED
+
+            return OrderStatus.PENDING
+
+        except Exception as e:
+            self.logger.error(f"주문 상태 확인 실패 ({order_key}): {e}")
+            return OrderStatus.PENDING
+
+    async def _handle_timeout_order(self, order_key: str, managed_order: ManagedOrder):
+        """타임아웃된 주문 처리"""
+        self.logger.warning(f"주문 타임아웃: {order_key}")
+
+        try:
+            # 주문 취소 시도
+            await managed_order.exchange.cancel_order(
+                managed_order.order.id,
+                managed_order.order.symbol
+            )
+
+            managed_order.status = OrderStatus.TIMEOUT
+            self.logger.info(f"타임아웃된 주문 취소 완료: {order_key}")
+
+        except Exception as e:
+            self.logger.error(f"타임아웃된 주문 취소 실패 ({order_key}): {e}")
+
+    async def cancel_order(self, order_key: str) -> bool:
+        """주문 취소"""
+        if order_key not in self.managed_orders:
+            return False
+
+        managed_order = self.managed_orders[order_key]
+
+        try:
+            await managed_order.exchange.cancel_order(
+                managed_order.order.id,
+                managed_order.order.symbol
+            )
+
+            managed_order.status = OrderStatus.CANCELLED
+            self.logger.info(f"주문 취소 완료: {order_key}")
+            return True
+
+        except Exception as e:
+            self.logger.error(f"주문 취소 실패 ({order_key}): {e}")
+            return False
+
+    def get_order(self, order_key: str) -> Optional[Order]:
+        """주문 정보 조회"""
+        if order_key in self.managed_orders:
+            return self.managed_orders[order_key].order
+        return None
+
+    def remove_order(self, order_key: str):
+        """주문 제거"""
+        if order_key in self.managed_orders:
+            del self.managed_orders[order_key]
+            self.logger.info(f"주문 관리 종료: {order_key}")
+
+    async def cleanup_completed_orders(self):
+        """완료된 주문들 정리"""
+        completed_keys = [
+            key for key, managed_order in self.managed_orders.items()
+            if managed_order.status in [OrderStatus.FILLED, OrderStatus.CANCELLED, OrderStatus.TIMEOUT]
+        ]
+
+        for key in completed_keys:
+            self.remove_order(key)
+
+        if completed_keys:
+            self.logger.info(f"완료된 주문 {len(completed_keys)}개 정리 완료")

--- a/arb_trading/core/position_manager.py
+++ b/arb_trading/core/position_manager.py
@@ -1,0 +1,337 @@
+# arb_trading/core/position_manager.py
+import asyncio
+import time
+from typing import Dict, List, Optional, Any
+from dataclasses import dataclass, field
+from enum import Enum
+from ..exchanges.base import BaseExchange, Order, Position, OrderSide, OrderType, Direction
+from ..utils.notifications import NotificationManager
+import logging
+
+
+class PositionStatus(Enum):
+    PENDING = "pending"  # 진입 대기중
+    OPEN = "open"  # 포지션 오픈
+    CLOSING = "closing"  # 청산 중
+    CLOSED = "closed"  # 청산 완료
+
+
+@dataclass
+class ArbitragePosition:
+    """차익거래 포지션"""
+    symbol: str
+    long_exchange: BaseExchange
+    short_exchange: BaseExchange
+    long_symbol: str
+    short_symbol: str
+    quantity: float
+    entry_spread: float
+    entry_spread_signed: float
+    entry_timestamp: float
+    status: PositionStatus = PositionStatus.PENDING
+
+    # 주문 정보
+    long_order_id: Optional[str] = None
+    short_order_id: Optional[str] = None
+    long_filled: float = 0.0
+    short_filled: float = 0.0
+
+    # 진입 가격
+    long_entry_price: Optional[float] = None
+    short_entry_price: Optional[float] = None
+
+    # 청산 정보
+    exit_timestamp: Optional[float] = None
+    exit_spread: Optional[float] = None
+    pnl: float = 0.0
+
+
+class PositionManager:
+    """포지션 관리 클래스"""
+
+    def __init__(self, max_positions: int = 3,
+                 position_timeout: int = 300,
+                 order_timeout: int = 60,
+                 notification_manager: Optional[NotificationManager] = None):
+
+        self.max_positions = max_positions
+        self.position_timeout = position_timeout
+        self.order_timeout = order_timeout
+        self.notification_manager = notification_manager
+        self.logger = logging.getLogger(__name__)
+
+        self.positions: Dict[str, ArbitragePosition] = {}
+
+    def can_open_position(self) -> bool:
+        """새 포지션 개설 가능 여부"""
+        open_count = len([p for p in self.positions.values()
+                          if p.status in [PositionStatus.PENDING, PositionStatus.OPEN]])
+        return open_count < self.max_positions
+
+    def add_position(self, position: ArbitragePosition) -> bool:
+        """포지션 추가"""
+        if not self.can_open_position():
+            self.logger.warning(f"최대 포지션 수({self.max_positions}) 도달로 인해 {position.symbol} 포지션 개설 불가")
+            return False
+
+        if position.symbol in self.positions:
+            self.logger.warning(f"이미 존재하는 포지션: {position.symbol}")
+            return False
+
+        self.positions[position.symbol] = position
+        self.logger.info(f"새 포지션 추가: {position.symbol} (총 {len(self.positions)}개)")
+
+        if self.notification_manager:
+            asyncio.create_task(self.notification_manager.send_slack_notification(
+                f"새 차익거래 포지션 개설: {position.symbol}\n"
+                f"진입 스프레드: {position.entry_spread_signed:+.2f}%\n"
+                f"롱: {position.long_exchange.name} | 숏: {position.short_exchange.name}"
+            ))
+
+        return True
+
+    async def update_position_status(self, symbol: str) -> bool:
+        """포지션 상태 업데이트"""
+        if symbol not in self.positions:
+            return False
+
+        position = self.positions[symbol]
+
+        try:
+            # 주문 상태 확인
+            if position.status == PositionStatus.PENDING:
+                long_filled = 0.0
+                short_filled = 0.0
+
+                if position.long_order_id:
+                    long_order = await position.long_exchange.fetch_order(
+                        position.long_order_id, position.long_symbol
+                    )
+                    long_filled = long_order.filled
+                    if long_order.average:
+                        position.long_entry_price = long_order.average
+
+                if position.short_order_id:
+                    short_order = await position.short_exchange.fetch_order(
+                        position.short_order_id, position.short_symbol
+                    )
+                    short_filled = short_order.filled
+                    if short_order.average:
+                        position.short_entry_price = short_order.average
+
+                position.long_filled = long_filled
+                position.short_filled = short_filled
+
+                # 양쪽 모두 체결된 경우
+                if long_filled > 0 and short_filled > 0:
+                    position.status = PositionStatus.OPEN
+                    self.logger.info(f"포지션 체결 완료: {symbol}")
+
+                    if self.notification_manager:
+                        await self.notification_manager.send_slack_notification(
+                            f"포지션 체결 완료: {symbol}\n"
+                            f"롱: {long_filled:.4f} @ {position.long_entry_price or 'N/A'}\n"
+                            f"숏: {short_filled:.4f} @ {position.short_entry_price or 'N/A'}"
+                        )
+
+                # 한쪽만 체결된 경우 타임아웃 체크
+                elif (long_filled > 0 or short_filled > 0) and \
+                        time.time() - position.entry_timestamp > self.order_timeout:
+
+                    await self._handle_partial_fill(position)
+
+            return True
+
+        except Exception as e:
+            self.logger.error(f"포지션 상태 업데이트 실패 ({symbol}): {e}")
+            return False
+
+    async def _handle_partial_fill(self, position: ArbitragePosition):
+        """부분 체결 처리"""
+        self.logger.warning(f"부분 체결 감지: {position.symbol}")
+
+        try:
+            # 체결되지 않은 쪽을 시장가로 체결 시도
+            if position.long_filled > 0 and position.short_filled == 0:
+                self.logger.info(f"롱 포지션만 체결됨 - 시장가 숏 주문 실행: {position.symbol}")
+
+                short_order = await position.short_exchange.create_order(
+                    symbol=position.short_symbol,
+                    side=OrderSide.SELL,
+                    order_type=OrderType.MARKET,
+                    amount=position.quantity,
+                    params={'category': 'linear'} if position.short_exchange.name == 'bybit' else {}
+                )
+
+                position.short_order_id = short_order.id
+                position.short_filled = short_order.filled
+                if short_order.average:
+                    position.short_entry_price = short_order.average
+
+            elif position.short_filled > 0 and position.long_filled == 0:
+                self.logger.info(f"숏 포지션만 체결됨 - 시장가 롱 주문 실행: {position.symbol}")
+
+                long_order = await position.long_exchange.create_order(
+                    symbol=position.long_symbol,
+                    side=OrderSide.BUY,
+                    order_type=OrderType.MARKET,
+                    amount=position.quantity,
+                    params={'category': 'linear'} if position.long_exchange.name == 'bybit' else {}
+                )
+
+                position.long_order_id = long_order.id
+                position.long_filled = long_order.filled
+                if long_order.average:
+                    position.long_entry_price = long_order.average
+
+            # 양쪽 모두 체결됨 확인
+            if position.long_filled > 0 and position.short_filled > 0:
+                position.status = PositionStatus.OPEN
+
+                if self.notification_manager:
+                    await self.notification_manager.send_slack_notification(
+                        f"부분 체결 복구 완료: {position.symbol}\n"
+                        f"시장가 주문으로 포지션 완성"
+                    )
+
+        except Exception as e:
+            self.logger.error(f"부분 체결 처리 실패 ({position.symbol}): {e}")
+
+            if self.notification_manager:
+                await self.notification_manager.send_slack_notification(
+                    f"⚠️ 부분 체결 처리 실패: {position.symbol}\n"
+                    f"수동 확인 필요: {e}",
+                    level="ERROR"
+                )
+
+    async def close_position(self, symbol: str, reason: str = "조건 충족") -> bool:
+        """포지션 청산"""
+        if symbol not in self.positions:
+            return False
+
+        position = self.positions[symbol]
+
+        if position.status != PositionStatus.OPEN:
+            self.logger.warning(f"청산 불가능한 포지션 상태: {position.symbol} ({position.status})")
+            return False
+
+        try:
+            position.status = PositionStatus.CLOSING
+            position.exit_timestamp = time.time()
+
+            self.logger.info(f"포지션 청산 시작: {symbol} (사유: {reason})")
+
+            # 시장가로 청산
+            tasks = []
+
+            # 롱 포지션 청산 (매도)
+            if position.long_filled > 0:
+                tasks.append(self._close_long_position(position))
+
+            # 숏 포지션 청산 (매수)
+            if position.short_filled > 0:
+                tasks.append(self._close_short_position(position))
+
+            results = await asyncio.gather(*tasks, return_exceptions=True)
+
+            # 결과 처리
+            success = True
+            for result in results:
+                if isinstance(result, Exception):
+                    self.logger.error(f"청산 중 오류: {result}")
+                    success = False
+
+            if success:
+                position.status = PositionStatus.CLOSED
+                self.logger.info(f"포지션 청산 완료: {symbol}")
+
+                if self.notification_manager:
+                    await self.notification_manager.send_slack_notification(
+                        f"포지션 청산 완료: {symbol}\n"
+                        f"사유: {reason}\n"
+                        f"예상 수익: {position.pnl:.2f} USDT"
+                    )
+
+            return success
+
+        except Exception as e:
+            self.logger.error(f"포지션 청산 실패 ({symbol}): {e}")
+
+            if self.notification_manager:
+                await self.notification_manager.send_slack_notification(
+                    f"⚠️ 포지션 청산 실패: {symbol}\n"
+                    f"오류: {e}",
+                    level="ERROR"
+                )
+
+            return False
+
+    async def _close_long_position(self, position: ArbitragePosition):
+        """롱 포지션 청산"""
+        order = await position.long_exchange.create_order(
+            symbol=position.long_symbol,
+            side=OrderSide.SELL,
+            order_type=OrderType.MARKET,
+            amount=position.long_filled,
+            params={'category': 'linear'} if position.long_exchange.name == 'bybit' else {}
+        )
+
+        self.logger.info(f"롱 포지션 청산: {position.symbol} - {order.filled}개")
+
+    async def _close_short_position(self, position: ArbitragePosition):
+        """숏 포지션 청산"""
+        order = await position.short_exchange.create_order(
+            symbol=position.short_symbol,
+            side=OrderSide.BUY,
+            order_type=OrderType.MARKET,
+            amount=position.short_filled,
+            params={'category': 'linear'} if position.short_exchange.name == 'bybit' else {}
+        )
+
+        self.logger.info(f"숏 포지션 청산: {position.symbol} - {order.filled}개")
+
+    async def close_all_positions(self, reason: str = "시스템 종료"):
+        """모든 포지션 청산"""
+        open_positions = [
+            symbol for symbol, pos in self.positions.items()
+            if pos.status in [PositionStatus.OPEN, PositionStatus.PENDING]
+        ]
+
+        if not open_positions:
+            self.logger.info("청산할 포지션이 없습니다")
+            return
+
+        self.logger.info(f"전체 포지션 청산 시작: {len(open_positions)}개")
+
+        if self.notification_manager:
+            await self.notification_manager.send_slack_notification(
+                f"⚠️ 전체 포지션 청산 시작\n"
+                f"대상: {', '.join(open_positions)}\n"
+                f"사유: {reason}",
+                level="WARNING"
+            )
+
+        tasks = []
+        for symbol in open_positions:
+            tasks.append(self.close_position(symbol, reason))
+
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+
+        success_count = sum(1 for r in results if r is True)
+        self.logger.info(f"전체 포지션 청산 완료: {success_count}/{len(open_positions)}개 성공")
+
+    def get_position_summary(self) -> Dict[str, Any]:
+        """포지션 요약 정보"""
+        total = len(self.positions)
+        by_status = {}
+
+        for pos in self.positions.values():
+            status = pos.status.value
+            by_status[status] = by_status.get(status, 0) + 1
+
+        return {
+            "총 포지션 수": total,
+            "상태별 분포": by_status,
+            "최대 포지션 수": self.max_positions,
+            "가용 슬롯": max(0, self.max_positions - by_status.get("pending", 0) - by_status.get("open", 0))
+        }

--- a/arb_trading/core/spread_monitor.py
+++ b/arb_trading/core/spread_monitor.py
@@ -1,0 +1,332 @@
+# arb_trading/core/spread_monitor.py (디버깅 강화 버전)
+import asyncio
+import time
+from typing import Dict, List, Optional, Tuple
+from dataclasses import dataclass
+from datetime import datetime
+from collections import defaultdict, deque
+from ..exchanges.base import BaseExchange, Ticker, Direction
+from ..utils.performance import PerformanceMonitor
+import logging
+
+
+@dataclass
+class SpreadData:
+    """스프레드 데이터"""
+    timestamp: str
+    symbol: str
+    binance_price: float
+    bybit_price: float
+    spread_pct: float
+    abs_spread_pct: float
+    direction: Direction
+    volume_24h: float
+
+
+class SpreadMonitor:
+    """스프레드 모니터링 클래스"""
+
+    def __init__(self, exchanges: Dict[str, BaseExchange],
+                 min_volume_usdt: float = 5000000,
+                 top_symbol_limit: int = 300,
+                 performance_monitor: Optional[PerformanceMonitor] = None):
+
+        self.exchanges = exchanges
+        self.min_volume_usdt = min_volume_usdt
+        self.top_symbol_limit = top_symbol_limit
+        self.performance_monitor = performance_monitor
+        self.logger = logging.getLogger(__name__)
+
+        # 캐시된 데이터
+        self._symbols_cache: Optional[List[str]] = None
+        self._last_symbols_update = 0
+        self._symbols_cache_ttl = 3600  # 1시간
+
+    async def get_common_symbols(self) -> List[str]:
+        """공통 거래 가능 심볼 조회 (캐시 활용)"""
+        now = time.time()
+
+        if (self._symbols_cache is None or
+                now - self._last_symbols_update > self._symbols_cache_ttl):
+
+            start_time = time.time()
+
+            try:
+                # 모든 거래소에서 심볼 목록 동시 조회
+                tasks = []
+                for name, exchange in self.exchanges.items():
+                    tasks.append(self._fetch_symbols_with_name(name, exchange))
+
+                results = await asyncio.gather(*tasks, return_exceptions=True)
+
+                # 결과 처리
+                exchange_symbols = {}
+                for result in results:
+                    if isinstance(result, Exception):
+                        self.logger.error(f"심볼 조회 실패: {result}")
+                        continue
+                    name, symbols = result
+                    exchange_symbols[name] = set(symbols)
+                    self.logger.debug(f"{name} 심볼 수: {len(symbols)}")
+
+                if len(exchange_symbols) < 2:
+                    raise Exception("최소 2개 거래소의 심볼이 필요합니다")
+
+                # 공통 심볼 찾기
+                common_symbols = set.intersection(*exchange_symbols.values())
+                self.logger.info(f"거래소간 공통 심볼: {len(common_symbols)}개")
+
+                # 거래량 기준 필터링
+                volumes = await self._get_volumes_data()
+
+                # 거래량 조건을 만족하는 심볼들
+                volume_filtered = []
+                for s in common_symbols:
+                    max_volume = max(
+                        volumes.get(exchange_name, {}).get(s, 0)
+                        for exchange_name in volumes.keys()
+                    )
+                    if max_volume >= self.min_volume_usdt:
+                        volume_filtered.append(s)
+
+                self.logger.info(f"거래량 조건 통과: {len(volume_filtered)}개 (최소: {self.min_volume_usdt:,} USDT)")
+
+                # 거래량 기준 정렬 후 상위 N개 선택
+                def get_max_volume(symbol):
+                    return max(volumes.get(exchange_name, {}).get(symbol, 0)
+                               for exchange_name in volumes.keys())
+
+                volume_ranked = sorted(volume_filtered, key=get_max_volume, reverse=True)
+                self._symbols_cache = volume_ranked[:self.top_symbol_limit]
+                self._last_symbols_update = now
+
+                if self.performance_monitor:
+                    self.performance_monitor.record_fetch_time(time.time() - start_time)
+
+                self.logger.info(f"최종 사용 심볼: {len(self._symbols_cache)}개")
+
+                # 상위 10개 심볼과 거래량 출력 (디버깅용)
+                self.logger.debug("상위 10개 심볼:")
+                for i, symbol in enumerate(self._symbols_cache[:10]):
+                    volume = get_max_volume(symbol)
+                    self.logger.debug(f"  {i + 1}. {symbol}: {volume:,.0f} USDT")
+
+            except Exception as e:
+                self.logger.error(f"심볼 조회 중 오류: {e}")
+                if self._symbols_cache is None:
+                    self._symbols_cache = []
+
+        return self._symbols_cache
+
+    async def _fetch_symbols_with_name(self, name: str, exchange: BaseExchange) -> Tuple[str, List[str]]:
+        """거래소별 심볼 조회 (이름 포함)"""
+        if self.performance_monitor:
+            self.performance_monitor.record_api_call(name)
+
+        symbols = await exchange.fetch_symbols()
+        return name, symbols
+
+    async def _get_volumes_data(self) -> Dict[str, Dict[str, float]]:
+        """모든 거래소에서 거래량 데이터 조회"""
+        tasks = []
+        for name, exchange in self.exchanges.items():
+            tasks.append(self._fetch_volumes_with_name(name, exchange))
+
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+
+        volumes = {}
+        for result in results:
+            if isinstance(result, Exception):
+                self.logger.error(f"거래량 조회 실패: {result}")
+                continue
+            name, volume_data = result
+            volumes[name] = volume_data
+            self.logger.debug(f"{name} 거래량 데이터: {len(volume_data)}개")
+
+        return volumes
+
+    async def _fetch_volumes_with_name(self, name: str, exchange: BaseExchange) -> Tuple[str, Dict[str, float]]:
+        """거래소별 거래량 조회 (이름 포함)"""
+        if self.performance_monitor:
+            self.performance_monitor.record_api_call(name)
+
+        volumes = await exchange.fetch_24h_volumes()
+        return name, volumes
+
+    def _validate_price_pair(self, symbol: str, binance_price: float, bybit_price: float) -> bool:
+        """가격 쌍 유효성 검사"""
+        # 기본 검사
+        if binance_price <= 0 or bybit_price <= 0:
+            self.logger.warning(f"{symbol}: 유효하지 않은 가격 - B:{binance_price}, Y:{bybit_price}")
+            return False
+
+        # 극단적 차이 검사 (10배 이상 차이)
+        ratio = max(binance_price, bybit_price) / min(binance_price, bybit_price)
+        if ratio > 10.0:
+            self.logger.warning(f"{symbol}: 극단적 가격 차이 - B:{binance_price}, Y:{bybit_price} (비율: {ratio:.2f})")
+            return False
+
+        # 가격대별 현실성 검사
+        avg_price = (binance_price + bybit_price) / 2
+        spread_pct = abs(binance_price - bybit_price) / min(binance_price, bybit_price) * 100
+
+        # 가격대별 최대 허용 스프레드
+        if avg_price >= 1000:  # 고가 코인 (BTC 등)
+            max_spread = 1.0  # 1%
+        elif avg_price >= 10:  # 중가 코인 (ETH 등)
+            max_spread = 2.0  # 2%
+        elif avg_price >= 0.1:  # 저가 코인
+            max_spread = 5.0  # 5%
+        else:  # 극저가 코인
+            max_spread = 10.0  # 10%
+
+        if spread_pct > max_spread:
+            self.logger.warning(
+                f"{symbol}: 비현실적 스프레드 - B:{binance_price}, Y:{bybit_price} "
+                f"({spread_pct:.2f}% > 최대 {max_spread}%)"
+            )
+            return False
+
+        return True
+
+    async def fetch_spread_data(self) -> List[SpreadData]:
+        """스프레드 데이터 조회 (상세 성능 로깅)"""
+        cycle_start_time = time.time()
+
+        try:
+            # 성능 모니터링 사이클 시작
+            if self.performance_monitor:
+                self.performance_monitor.start_fetch_cycle()
+
+            # 공통 심볼 조회
+            symbols = await self.get_common_symbols()
+            if not symbols:
+                return []
+
+            # 데이터 페치 시작
+            fetch_start_time = time.time()
+
+            # 모든 거래소에서 가격 데이터 동시 조회 (개별 타이밍 측정)
+            tasks = []
+            for name, exchange in self.exchanges.items():
+                tasks.append(self._fetch_tickers_with_timing(name, exchange))
+
+            results = await asyncio.gather(*tasks, return_exceptions=True)
+
+            fetch_end_time = time.time()
+            fetch_duration = fetch_end_time - fetch_start_time
+
+            # 가격 데이터 정리
+            exchange_prices = {}
+            for result in results:
+                if isinstance(result, Exception):
+                    self.logger.error(f"가격 조회 실패: {result}")
+                    continue
+                name, tickers = result
+                exchange_prices[name] = {symbol: ticker.last_price for symbol, ticker in tickers.items()}
+
+            if len(exchange_prices) < 2:
+                self.logger.warning("충분한 가격 데이터를 조회할 수 없습니다")
+                return []
+
+            # 스프레드 계산 시작
+            calc_start_time = time.time()
+            spread_list = []
+
+            for symbol in symbols:
+                # 가격 데이터 수집
+                prices = {}
+                for exchange_name in exchange_prices:
+                    if symbol in exchange_prices[exchange_name]:
+                        prices[exchange_name] = exchange_prices[exchange_name][symbol]
+
+                if len(prices) < 2:
+                    continue
+
+                # 바이낸스와 바이빗 가격
+                binance_price = prices.get('binance')
+                bybit_price = prices.get('bybit')
+
+                if binance_price and bybit_price and binance_price > 0 and bybit_price > 0:
+                    # 스프레드 계산
+                    higher_price = max(binance_price, bybit_price)
+                    lower_price = min(binance_price, bybit_price)
+                    abs_spread_pct = (higher_price - lower_price) / lower_price * 100
+
+                    # 방향성 고려
+                    if binance_price > bybit_price:
+                        spread_pct = abs_spread_pct
+                        direction = Direction.BINANCE_GT_BYBIT
+                    else:
+                        spread_pct = -abs_spread_pct
+                        direction = Direction.BYBIT_GT_BINANCE
+
+                    # 현실적인 스프레드만 포함 (5% 이하)
+                    if abs_spread_pct <= 5.0:
+                        spread_list.append(SpreadData(
+                            timestamp=datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S"),
+                            symbol=symbol,
+                            binance_price=binance_price,
+                            bybit_price=bybit_price,
+                            spread_pct=spread_pct,
+                            abs_spread_pct=abs_spread_pct,
+                            direction=direction,
+                            volume_24h=0.0
+                        ))
+
+            # 절대값 스프레드 기준으로 정렬
+            spread_list.sort(key=lambda x: x.abs_spread_pct, reverse=True)
+
+            calc_end_time = time.time()
+            calc_duration = calc_end_time - calc_start_time
+            total_duration = calc_end_time - cycle_start_time
+
+            # 성능 기록
+            if self.performance_monitor:
+                self.performance_monitor.record_fetch_time(fetch_duration)
+                self.performance_monitor.record_spread_calc_time(calc_duration, len(spread_list))
+                self.performance_monitor.record_total_cycle_time(
+                    total_duration, fetch_duration, calc_duration, len(spread_list)
+                )
+
+            return spread_list
+
+        except Exception as e:
+            self.logger.error(f"스프레드 데이터 조회 실패: {e}")
+            if self.performance_monitor:
+                self.performance_monitor.record_error("spread_fetch_error")
+            return []
+
+    async def _fetch_tickers_with_timing(self, name: str, exchange: BaseExchange) -> Tuple[str, Dict[str, Ticker]]:
+        """거래소별 티커 조회 (타이밍 측정)"""
+        start_time = time.time()
+
+        try:
+            if self.performance_monitor:
+                self.performance_monitor.record_api_call(name)
+
+            tickers = await exchange.fetch_tickers()
+
+            duration = time.time() - start_time
+            if self.performance_monitor:
+                self.performance_monitor.record_exchange_fetch(
+                    name, "tickers", duration, success=True
+                )
+
+            return name, tickers
+
+        except Exception as e:
+            duration = time.time() - start_time
+            if self.performance_monitor:
+                self.performance_monitor.record_exchange_fetch(
+                    name, "tickers", duration, success=False, error_msg=str(e)
+                )
+            raise
+
+    async def _fetch_tickers_with_name(self, name: str, exchange: BaseExchange) -> Tuple[str, Dict[str, Ticker]]:
+        """거래소별 티커 조회 (이름 포함)"""
+        if self.performance_monitor:
+            self.performance_monitor.record_api_call(name)
+
+        tickers = await exchange.fetch_tickers()
+        return name, tickers

--- a/arb_trading/exchanges/__init__.py
+++ b/arb_trading/exchanges/__init__.py
@@ -1,0 +1,18 @@
+# arb_trading/exchanges/__init__.py
+"""거래소 모듈"""
+
+from .base import BaseExchange, OrderType, OrderSide, Direction, Ticker, Order, Position
+from .binance import BinanceExchange
+from .bybit import BybitExchange
+
+__all__ = [
+    'BaseExchange',
+    'OrderType',
+    'OrderSide',
+    'Direction',
+    'Ticker',
+    'Order',
+    'Position',
+    'BinanceExchange',
+    'BybitExchange'
+]

--- a/arb_trading/exchanges/base.py
+++ b/arb_trading/exchanges/base.py
@@ -1,0 +1,268 @@
+# arb_trading/exchanges/base.py (수정된 버전)
+from abc import ABC, abstractmethod
+from typing import Dict, List, Optional, Tuple, Any
+from dataclasses import dataclass
+from enum import Enum
+import asyncio
+import aiohttp
+import time
+import platform
+from ..utils.platform_utils import get_optimal_connector
+
+
+class OrderType(Enum):
+    MARKET = "market"
+    LIMIT = "limit"
+    STOP_LOSS = "stop_loss"
+
+
+class OrderSide(Enum):
+    BUY = "buy"
+    SELL = "sell"
+
+
+class Direction(Enum):
+    BINANCE_GT_BYBIT = "binance_gt_bybit"
+    BYBIT_GT_BINANCE = "bybit_gt_binance"
+
+
+@dataclass
+class Ticker:
+    symbol: str
+    last_price: float
+    bid: Optional[float] = None
+    ask: Optional[float] = None
+    volume_24h: float = 0.0
+    timestamp: int = 0
+
+
+@dataclass
+class Order:
+    id: str
+    symbol: str
+    side: OrderSide
+    type: OrderType
+    amount: float
+    price: Optional[float]
+    filled: float = 0.0
+    average: Optional[float] = None
+    status: str = "open"
+    timestamp: int = 0
+
+
+@dataclass
+class Position:
+    symbol: str
+    side: str
+    size: float
+    entry_price: float
+    mark_price: float
+    pnl: float = 0.0
+    percentage: float = 0.0
+
+
+class BaseExchange(ABC):
+    """거래소 공통 인터페이스"""
+
+    def __init__(self, api_key: str = "", secret: str = ""):
+        """
+        거래소 초기화 (testnet 제거)
+
+        Args:
+            api_key: API 키 (시뮬레이션에서는 빈 문자열 가능)
+            secret: API 시크릿 (시뮬레이션에서는 빈 문자열 가능)
+        """
+        self.api_key = api_key
+        self.secret = secret
+        self.session: Optional[aiohttp.ClientSession] = None
+        self._rate_limit_delay = 0.1  # 기본 레이트 리미트
+
+    async def __aenter__(self):
+        await self.connect()
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        await self.disconnect()
+
+    async def connect(self):
+        """연결 설정"""
+        if not self.session:
+            timeout = aiohttp.ClientTimeout(total=30, connect=10)
+
+            # Windows 호환 커넥터 사용
+            connector = get_optimal_connector()
+
+            self.session = aiohttp.ClientSession(
+                timeout=timeout,
+                connector=connector,
+                headers={
+                    'User-Agent': 'ArbitrageBot/1.0',
+                    'Accept': 'application/json',
+                    'Content-Type': 'application/json'
+                }
+            )
+
+    async def disconnect(self):
+        """연결 해제"""
+        if self.session:
+            await self.session.close()
+            self.session = None
+
+    # 추상 메소드들 (기존과 동일)
+    @abstractmethod
+    async def fetch_tickers(self) -> Dict[str, Ticker]:
+        """모든 티커 정보 조회"""
+        pass
+
+    @abstractmethod
+    async def fetch_ticker(self, symbol: str) -> Ticker:
+        """단일 티커 정보 조회"""
+        pass
+
+    @abstractmethod
+    async def fetch_24h_volumes(self) -> Dict[str, float]:
+        """24시간 거래량 조회"""
+        pass
+
+    @abstractmethod
+    async def fetch_symbols(self) -> List[str]:
+        """거래 가능한 심볼 목록 조회"""
+        pass
+
+    @abstractmethod
+    def normalize_symbol(self, raw_symbol: str) -> Optional[str]:
+        """심볼 표준화"""
+        pass
+
+    @abstractmethod
+    def calculate_quantity(self, symbol: str, price: float, target_usdt: float) -> float:
+        """목표 USDT 기준 수량 계산"""
+        pass
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """거래소 이름"""
+        pass
+
+    # 시뮬레이션에서만 사용하는 메소드들은 기본 구현 제공
+    async def fetch_balance(self) -> Dict[str, float]:
+        """잔고 조회 (시뮬레이션용)"""
+        return {'USDT': 10000.0}
+
+    async def create_order(self, symbol: str, side: OrderSide, order_type: OrderType,
+                           amount: float, price: Optional[float] = None,
+                           params: Optional[Dict] = None) -> Order:
+        """주문 생성 (시뮬레이션용)"""
+        return Order(
+            id=f"sim_{int(time.time())}",
+            symbol=symbol,
+            side=side,
+            type=order_type,
+            amount=amount,
+            price=price,
+            filled=amount,  # 시뮬레이션에서는 즉시 체결
+            average=price,
+            status='filled',
+            timestamp=self._get_timestamp()
+        )
+
+    async def fetch_order(self, order_id: str, symbol: str) -> Order:
+        """주문 조회 (시뮬레이션용)"""
+        return Order(
+            id=order_id,
+            symbol=symbol,
+            side=OrderSide.BUY,
+            type=OrderType.LIMIT,
+            amount=1.0,
+            price=100.0,
+            filled=1.0,
+            average=100.0,
+            status='filled',
+            timestamp=self._get_timestamp()
+        )
+
+    async def cancel_order(self, order_id: str, symbol: str) -> bool:
+        """주문 취소 (시뮬레이션용)"""
+        return True
+
+    async def fetch_positions(self) -> List[Position]:
+        """포지션 조회 (시뮬레이션용)"""
+        return []
+
+    async def set_leverage(self, symbol: str, leverage: int) -> bool:
+        """레버리지 설정 (시뮬레이션용)"""
+        return True
+
+    async def set_margin_mode(self, symbol: str, margin_mode: str) -> bool:
+        """마진 모드 설정 (시뮬레이션용)"""
+        return True
+
+    async def _request(self, method: str, url: str, params: Optional[Dict] = None,
+                       data: Optional[Dict] = None, headers: Optional[Dict] = None) -> Dict:
+        """공통 HTTP 요청 처리"""
+        if not self.session:
+            await self.connect()
+
+        # 레이트 리미트 적용
+        await asyncio.sleep(self._rate_limit_delay)
+
+        # 재시도 로직
+        max_retries = 3
+        for attempt in range(max_retries):
+            try:
+                # 요청 헤더 병합
+                request_headers = {}
+                if headers:
+                    request_headers.update(headers)
+
+                async with self.session.request(
+                        method=method,
+                        url=url,
+                        params=params,
+                        json=data,
+                        headers=request_headers,
+                        ssl=False  # SSL 검증 비활성화 (필요시)
+                ) as response:
+
+                    if response.status == 429:  # Too Many Requests
+                        wait_time = 2 ** attempt  # 지수 백오프
+                        await asyncio.sleep(wait_time)
+                        continue
+
+                    if response.status >= 400:
+                        error_text = await response.text()
+                        raise aiohttp.ClientResponseError(
+                            request_info=response.request_info,
+                            history=response.history,
+                            status=response.status,
+                            message=f"HTTP {response.status}: {error_text}"
+                        )
+
+                    return await response.json()
+
+            except asyncio.TimeoutError:
+                if attempt == max_retries - 1:
+                    raise Exception(f"{self.name} API 타임아웃")
+                await asyncio.sleep(1)
+
+            except aiohttp.ClientConnectorError as e:
+                if attempt == max_retries - 1:
+                    raise Exception(f"{self.name} 연결 실패: {e}")
+                await asyncio.sleep(2)
+
+            except aiohttp.ClientError as e:
+                if attempt == max_retries - 1:
+                    raise Exception(f"{self.name} API 요청 실패: {e}")
+                await asyncio.sleep(1)
+
+            except Exception as e:
+                if attempt == max_retries - 1:
+                    raise Exception(f"{self.name} 예상치 못한 오류: {e}")
+                await asyncio.sleep(1)
+
+        raise Exception(f"{self.name} API 요청 최대 재시도 초과")
+
+    def _get_timestamp(self) -> int:
+        """현재 타임스탬프 반환 (밀리초)"""
+        return int(time.time() * 1000)

--- a/arb_trading/exchanges/binance.py
+++ b/arb_trading/exchanges/binance.py
@@ -1,0 +1,321 @@
+# arb_trading/exchanges/binance.py
+import hashlib
+import hmac
+import urllib.parse
+from typing import Dict, List, Optional
+from .base import BaseExchange, Ticker, Order, Position, OrderType, OrderSide
+import asyncio
+
+
+class BinanceExchange(BaseExchange):
+    """바이낸스 선물 거래소 구현"""
+
+    def __init__(self, api_key: str, secret: str):
+        super().__init__(api_key, secret)
+
+        self.base_url = "https://fapi.binance.com"
+
+
+        self._rate_limit_delay = 0.05  # 바이낸스는 빠른 요청 허용
+        self._symbols_cache = {}
+        self._market_info = {}
+
+    @property
+    def name(self) -> str:
+        return "binance"
+
+    def _sign_request(self, params: Dict) -> str:
+        """요청 서명 생성"""
+        query_string = urllib.parse.urlencode(params)
+        signature = hmac.new(
+            self.secret.encode('utf-8'),
+            query_string.encode('utf-8'),
+            hashlib.sha256
+        ).hexdigest()
+        return signature
+
+    async def _signed_request(self, method: str, endpoint: str, params: Optional[Dict] = None) -> Dict:
+        """서명된 요청"""
+        if params is None:
+            params = {}
+
+        params['timestamp'] = self._get_timestamp()
+        signature = self._sign_request(params)
+        params['signature'] = signature
+
+        headers = {
+            'X-MBX-APIKEY': self.api_key
+        }
+
+        url = f"{self.base_url}{endpoint}"
+        return await self._request(method, url, params=params, headers=headers)
+
+    async def fetch_symbols(self) -> List[str]:
+        """거래 가능한 심볼 목록 조회"""
+        if self._symbols_cache:
+            return list(self._symbols_cache.keys())
+
+        try:
+            url = f"{self.base_url}/fapi/v1/exchangeInfo"
+            data = await self._request("GET", url)
+
+            symbols = []
+            for item in data.get('symbols', []):
+                if (item.get('contractType') == 'PERPETUAL' and
+                        item.get('quoteAsset') == 'USDT' and
+                        item.get('status') == 'TRADING'):
+
+                    symbol = item['symbol']
+                    symbols.append(symbol)
+
+                    # 마켓 정보 캐시
+                    self._market_info[symbol] = {
+                        'base_precision': item.get('baseAssetPrecision', 8),
+                        'quote_precision': item.get('quotePrecision', 8),
+                        'min_qty': 0.001,  # 기본값
+                        'tick_size': 0.01  # 기본값
+                    }
+
+                    # 필터에서 정확한 값 추출
+                    for filter_item in item.get('filters', []):
+                        if filter_item['filterType'] == 'LOT_SIZE':
+                            self._market_info[symbol]['min_qty'] = float(filter_item['minQty'])
+                        elif filter_item['filterType'] == 'PRICE_FILTER':
+                            self._market_info[symbol]['tick_size'] = float(filter_item['tickSize'])
+
+            self._symbols_cache = {s: s for s in symbols}
+            return symbols
+
+        except Exception as e:
+            raise Exception(f"바이낸스 심볼 조회 실패: {e}")
+
+    async def fetch_tickers(self) -> Dict[str, Ticker]:
+        """모든 티커 정보 조회"""
+        try:
+            url = f"{self.base_url}/fapi/v1/ticker/price"
+            price_data = await self._request("GET", url)
+
+            url = f"{self.base_url}/fapi/v1/ticker/24hr"
+            volume_data = await self._request("GET", url)
+
+            # 가격과 볼륨 데이터 결합
+            volume_dict = {item['symbol']: item for item in volume_data}
+
+            tickers = {}
+            for item in price_data:
+                symbol = item['symbol']
+                price = float(item['price'])
+
+                volume_info = volume_dict.get(symbol, {})
+
+                tickers[symbol] = Ticker(
+                    symbol=symbol,
+                    last_price=price,
+                    bid=None,  # 별도 API 필요
+                    ask=None,  # 별도 API 필요
+                    volume_24h=float(volume_info.get('quoteVolume', 0)),
+                    timestamp=self._get_timestamp()
+                )
+
+            return tickers
+
+        except Exception as e:
+            raise Exception(f"바이낸스 티커 조회 실패: {e}")
+
+    async def fetch_ticker(self, symbol: str) -> Ticker:
+        """단일 티커 정보 조회"""
+        try:
+            # Book ticker로 bid/ask 포함해서 조회
+            url = f"{self.base_url}/fapi/v1/ticker/bookTicker"
+            data = await self._request("GET", url, params={'symbol': symbol})
+
+            return Ticker(
+                symbol=symbol,
+                last_price=float(data['bidPrice']),  # 임시로 bid 사용
+                bid=float(data['bidPrice']),
+                ask=float(data['askPrice']),
+                volume_24h=0.0,  # 별도 조회 필요
+                timestamp=self._get_timestamp()
+            )
+
+        except Exception as e:
+            raise Exception(f"바이낸스 단일 티커 조회 실패 ({symbol}): {e}")
+
+    async def fetch_24h_volumes(self) -> Dict[str, float]:
+        """24시간 거래량 조회"""
+        try:
+            url = f"{self.base_url}/fapi/v1/ticker/24hr"
+            data = await self._request("GET", url)
+
+            return {
+                item['symbol']: float(item.get('quoteVolume', 0))
+                for item in data
+            }
+
+        except Exception as e:
+            raise Exception(f"바이낸스 거래량 조회 실패: {e}")
+
+    async def fetch_balance(self) -> Dict[str, float]:
+        """잔고 조회"""
+        try:
+            data = await self._signed_request("GET", "/fapi/v2/balance")
+            return {
+                item['asset']: float(item['balance'])
+                for item in data
+                if float(item['balance']) > 0
+            }
+
+        except Exception as e:
+            raise Exception(f"바이낸스 잔고 조회 실패: {e}")
+
+    async def create_order(self, symbol: str, side: OrderSide, order_type: OrderType,
+                           amount: float, price: Optional[float] = None,
+                           params: Optional[Dict] = None) -> Order:
+        """주문 생성"""
+        try:
+            order_params = {
+                'symbol': symbol,
+                'side': side.value.upper(),
+                'type': order_type.value.upper(),
+                'quantity': self._format_quantity(symbol, amount)
+            }
+
+            if order_type == OrderType.LIMIT and price:
+                order_params['price'] = self._format_price(symbol, price)
+                order_params['timeInForce'] = 'GTC'  # Good Till Cancel
+
+            if params:
+                order_params.update(params)
+
+            data = await self._signed_request("POST", "/fapi/v1/order", order_params)
+
+            return Order(
+                id=str(data['orderId']),
+                symbol=symbol,
+                side=side,
+                type=order_type,
+                amount=amount,
+                price=price,
+                filled=float(data.get('executedQty', 0)),
+                average=float(data.get('avgPrice', 0)) if data.get('avgPrice') else None,
+                status=data.get('status', 'NEW').lower(),
+                timestamp=int(data.get('updateTime', self._get_timestamp()))
+            )
+
+        except Exception as e:
+            raise Exception(f"바이낸스 주문 생성 실패 ({symbol}): {e}")
+
+    async def fetch_order(self, order_id: str, symbol: str) -> Order:
+        """주문 조회"""
+        try:
+            params = {
+                'symbol': symbol,
+                'orderId': order_id
+            }
+            data = await self._signed_request("GET", "/fapi/v1/order", params)
+
+            return Order(
+                id=str(data['orderId']),
+                symbol=symbol,
+                side=OrderSide.BUY if data['side'] == 'BUY' else OrderSide.SELL,
+                type=OrderType.MARKET if data['type'] == 'MARKET' else OrderType.LIMIT,
+                amount=float(data['origQty']),
+                price=float(data['price']) if data['price'] != '0' else None,
+                filled=float(data['executedQty']),
+                average=float(data['avgPrice']) if data.get('avgPrice') and data['avgPrice'] != '0' else None,
+                status=data['status'].lower(),
+                timestamp=int(data['updateTime'])
+            )
+
+        except Exception as e:
+            raise Exception(f"바이낸스 주문 조회 실패 ({order_id}): {e}")
+
+    async def cancel_order(self, order_id: str, symbol: str) -> bool:
+        """주문 취소"""
+        try:
+            params = {
+                'symbol': symbol,
+                'orderId': order_id
+            }
+            await self._signed_request("DELETE", "/fapi/v1/order", params)
+            return True
+
+        except Exception as e:
+            raise Exception(f"바이낸스 주문 취소 실패 ({order_id}): {e}")
+
+    async def fetch_positions(self) -> List[Position]:
+        """포지션 조회"""
+        try:
+            data = await self._signed_request("GET", "/fapi/v2/positionRisk")
+
+            positions = []
+            for item in data:
+                if float(item['positionAmt']) != 0:
+                    positions.append(Position(
+                        symbol=item['symbol'],
+                        side='long' if float(item['positionAmt']) > 0 else 'short',
+                        size=abs(float(item['positionAmt'])),
+                        entry_price=float(item['entryPrice']),
+                        mark_price=float(item['markPrice']),
+                        pnl=float(item['unRealizedProfit']),
+                        percentage=float(item['percentage'])
+                    ))
+
+            return positions
+
+        except Exception as e:
+            raise Exception(f"바이낸스 포지션 조회 실패: {e}")
+
+    async def set_leverage(self, symbol: str, leverage: int) -> bool:
+        """레버리지 설정"""
+        try:
+            params = {
+                'symbol': symbol,
+                'leverage': leverage
+            }
+            await self._signed_request("POST", "/fapi/v1/leverage", params)
+            return True
+
+        except Exception as e:
+            if "leverage not modified" in str(e).lower():
+                return True  # 이미 설정된 경우
+            raise Exception(f"바이낸스 레버리지 설정 실패 ({symbol}): {e}")
+
+    async def set_margin_mode(self, symbol: str, margin_mode: str) -> bool:
+        """마진 모드 설정"""
+        try:
+            params = {
+                'symbol': symbol,
+                'marginType': margin_mode.upper()  # ISOLATED 또는 CROSSED
+            }
+            await self._signed_request("POST", "/fapi/v1/marginType", params)
+            return True
+
+        except Exception as e:
+            if "no need to change margin type" in str(e).lower():
+                return True  # 이미 설정된 경우
+            raise Exception(f"바이낸스 마진 모드 설정 실패 ({symbol}): {e}")
+
+    def normalize_symbol(self, raw_symbol: str) -> Optional[str]:
+        """심볼 표준화"""
+        formatted = raw_symbol.replace('/', '').replace(':', '').upper()
+        return self._symbols_cache.get(formatted)
+
+    def calculate_quantity(self, symbol: str, price: float, target_usdt: float) -> float:
+        """목표 USDT 기준 수량 계산"""
+        qty = target_usdt / price
+
+        if symbol in self._market_info:
+            min_qty = self._market_info[symbol]['min_qty']
+            if qty < min_qty:
+                qty = min_qty
+
+        return qty
+
+    def _format_quantity(self, symbol: str, quantity: float) -> str:
+        """수량 포맷팅 (round 제거)"""
+        return str(quantity)  # round() 없이 그대로 문자열 변환
+
+    def _format_price(self, symbol: str, price: float) -> str:
+        """가격 포맷팅 (round 제거)"""
+        return str(price)  # round() 없이 그대로 문자열 변환

--- a/arb_trading/exchanges/bybit.py
+++ b/arb_trading/exchanges/bybit.py
@@ -1,0 +1,308 @@
+# arb_trading/exchanges/bybit.py (영구계약만 필터링)
+import hashlib
+import hmac
+import urllib.parse
+import json
+from typing import Dict, List, Optional
+from .base import BaseExchange, Ticker, Order, Position, OrderType, OrderSide
+import asyncio
+import logging
+
+
+class BybitExchange(BaseExchange):
+    """바이빗 선물 거래소 구현"""
+
+    def __init__(self, api_key: str = "", secret: str = ""):
+        super().__init__(api_key, secret)
+
+        # 항상 실제 메인넷 사용
+        self.base_url = "https://api.bybit.com"
+
+        self._rate_limit_delay = 0.1
+        self._symbols_cache = {}
+        self._market_info = {}
+        self.logger = logging.getLogger(f"{__name__}.{self.__class__.__name__}")
+
+    @property
+    def name(self) -> str:
+        return "bybit"
+
+    def _safe_float(self, value, default: float = 0.0) -> float:
+        """안전한 float 변환"""
+        if value is None or value == '' or value == '0':
+            return default
+        try:
+            return float(value)
+        except (ValueError, TypeError):
+            return default
+
+    def _is_perpetual_contract(self, symbol: str) -> bool:
+        """영구계약인지 확인 (만료일이 없는 계약)"""
+        # 영구계약은 단순히 BTCUSDT, ETHUSDT 형태
+        # 선물계약은 BTCUSDT-04JUL25, BTCUSDT-26DEC25 형태
+
+        if '-' in symbol:
+            return False  # 만료일이 있는 선물계약
+
+        # USDT로 끝나는 영구계약만 허용
+        if symbol.endswith('USDT'):
+            return True
+
+        return False
+
+    async def fetch_tickers(self) -> Dict[str, Ticker]:
+        """모든 티커 정보 조회 (영구계약만)"""
+        try:
+            url = f"{self.base_url}/v5/market/tickers"
+            params = {'category': 'linear'}
+            data = await self._request("GET", url, params=params)
+
+            if data.get('retCode') != 0:
+                raise Exception(f"바이빗 API 오류: {data.get('retMsg')}")
+
+            result_list = data.get('result', {}).get('list', [])
+
+            tickers = {}
+            perpetual_count = 0
+            futures_count = 0
+
+            for item in result_list:
+                try:
+                    symbol = item['symbol']
+
+                    # 영구계약만 필터링
+                    if not self._is_perpetual_contract(symbol):
+                        futures_count += 1
+                        continue
+
+                    perpetual_count += 1
+
+                    # 가격 추출
+                    last_price = float(item['lastPrice'])
+
+                    if last_price <= 0:
+                        self.logger.debug(f"{symbol}: 유효하지 않은 lastPrice ({last_price})")
+                        continue
+
+                    bid_price = self._safe_float(item.get('bid1Price'))
+                    ask_price = self._safe_float(item.get('ask1Price'))
+                    volume_24h = self._safe_float(item.get('turnover24h'))
+
+                    # 디버깅: 주요 심볼들의 가격 출력
+                    if symbol in ['BTCUSDT', 'ETHUSDT', 'ADAUSDT']:
+                        self.logger.info(
+                            f"바이빗 {symbol}: last={last_price}, bid={bid_price}, ask={ask_price}"
+                        )
+
+                    tickers[symbol] = Ticker(
+                        symbol=symbol,
+                        last_price=last_price,
+                        bid=bid_price if bid_price > 0 else None,
+                        ask=ask_price if ask_price > 0 else None,
+                        volume_24h=volume_24h,
+                        timestamp=self._get_timestamp()
+                    )
+
+                except (KeyError, ValueError, TypeError) as e:
+                    self.logger.debug(f"티커 파싱 실패 ({item.get('symbol', 'Unknown')}): {e}")
+                    continue
+
+            self.logger.info(
+                f"바이빗 티커 조회 완료: {len(tickers)}개 영구계약 "
+                f"(전체: {perpetual_count + futures_count}개, 선물 제외: {futures_count}개)"
+            )
+
+            return tickers
+
+        except Exception as e:
+            self.logger.error(f"바이빗 티커 조회 실패: {e}")
+            raise Exception(f"바이빗 티커 조회 실패: {e}")
+
+    async def fetch_ticker(self, symbol: str) -> Ticker:
+        """단일 티커 정보 조회"""
+        try:
+            # 영구계약인지 먼저 확인
+            if not self._is_perpetual_contract(symbol):
+                raise Exception(f"영구계약이 아님: {symbol}")
+
+            url = f"{self.base_url}/v5/market/tickers"
+            params = {'category': 'linear', 'symbol': symbol}
+            data = await self._request("GET", url, params=params)
+
+            if data.get('retCode') != 0:
+                raise Exception(f"바이빗 API 오류: {data.get('retMsg')}")
+
+            items = data.get('result', {}).get('list', [])
+            if not items:
+                raise Exception(f"심볼을 찾을 수 없음: {symbol}")
+
+            item = items[0]
+
+            # 원시 데이터 로깅 (디버깅용)
+            self.logger.debug(f"바이빗 {symbol} 원시 데이터:")
+            self.logger.debug(f"  lastPrice: {item.get('lastPrice')}")
+            self.logger.debug(f"  markPrice: {item.get('markPrice')}")
+            self.logger.debug(f"  indexPrice: {item.get('indexPrice')}")
+            self.logger.debug(f"  bid1Price: {item.get('bid1Price')}")
+            self.logger.debug(f"  ask1Price: {item.get('ask1Price')}")
+
+            last_price = float(item['lastPrice'])
+
+            if last_price <= 0:
+                raise Exception(f"유효하지 않은 가격: {symbol} -> {last_price}")
+
+            return Ticker(
+                symbol=symbol,
+                last_price=last_price,
+                bid=self._safe_float(item.get('bid1Price')),
+                ask=self._safe_float(item.get('ask1Price')),
+                volume_24h=self._safe_float(item.get('turnover24h')),
+                timestamp=self._get_timestamp()
+            )
+
+        except Exception as e:
+            self.logger.error(f"바이빗 단일 티커 조회 실패 ({symbol}): {e}")
+            raise Exception(f"바이빗 단일 티커 조회 실패 ({symbol}): {e}")
+
+    async def fetch_24h_volumes(self) -> Dict[str, float]:
+        """24시간 거래량 조회 (영구계약만)"""
+        try:
+            tickers = await self.fetch_tickers()  # 이미 영구계약만 필터링됨
+            volumes = {}
+
+            for symbol, ticker in tickers.items():
+                if ticker.volume_24h > 0:
+                    volumes[symbol] = ticker.volume_24h
+
+            self.logger.info(f"바이빗 거래량 조회 완료: {len(volumes)}개")
+            return volumes
+
+        except Exception as e:
+            self.logger.error(f"바이빗 거래량 조회 실패: {e}")
+            raise Exception(f"바이빗 거래량 조회 실패: {e}")
+
+    async def fetch_symbols(self) -> List[str]:
+        """거래 가능한 심볼 목록 조회 (영구계약만)"""
+        if self._symbols_cache:
+            return list(self._symbols_cache.keys())
+
+        try:
+            url = f"{self.base_url}/v5/market/instruments-info"
+            params = {'category': 'linear'}
+            data = await self._request("GET", url, params=params)
+
+            if data.get('retCode') != 0:
+                raise Exception(f"바이빗 API 오류: {data.get('retMsg')}")
+
+            symbols = []
+            perpetual_count = 0
+            futures_count = 0
+
+            for item in data.get('result', {}).get('list', []):
+                symbol = item.get('symbol', '')
+
+                # 영구계약 필터링
+                if not self._is_perpetual_contract(symbol):
+                    futures_count += 1
+                    continue
+
+                # 추가 조건: USDT 영구계약, 거래 중
+                if (item.get('quoteCoin') == 'USDT' and
+                        item.get('status') == 'Trading' and
+                        item.get('contractType') == 'LinearPerpetual'):
+                    symbols.append(symbol)
+                    perpetual_count += 1
+
+                    # 마켓 정보 캐시
+                    lot_size_filter = item.get('lotSizeFilter', {})
+                    price_filter = item.get('priceFilter', {})
+
+                    self._market_info[symbol] = {
+                        'min_qty': self._safe_float(lot_size_filter.get('minOrderQty', '0.001')),
+                        'qty_step': self._safe_float(lot_size_filter.get('qtyStep', '0.001')),
+                        'tick_size': self._safe_float(price_filter.get('tickSize', '0.01'))
+                    }
+
+            self._symbols_cache = {s: s for s in symbols}
+            self.logger.info(
+                f"바이빗 심볼 조회 완료: {len(symbols)}개 영구계약 "
+                f"(전체: {perpetual_count + futures_count}개, 선물 제외: {futures_count}개)"
+            )
+
+            # 주요 심볼들이 포함되었는지 확인
+            major_symbols = ['BTCUSDT', 'ETHUSDT', 'ADAUSDT', 'SOLUSDT']
+            found_majors = [s for s in major_symbols if s in symbols]
+            self.logger.info(f"주요 심볼 포함: {found_majors}")
+
+            return symbols
+
+        except Exception as e:
+            self.logger.error(f"바이빗 심볼 조회 실패: {e}")
+            raise Exception(f"바이빗 심볼 조회 실패: {e}")
+
+    def normalize_symbol(self, raw_symbol: str) -> Optional[str]:
+        """심볼 표준화"""
+        formatted = raw_symbol.replace('/', '').replace(':', '').upper()
+
+        # 영구계약인지 확인
+        if not self._is_perpetual_contract(formatted):
+            return None
+
+        return self._symbols_cache.get(formatted)
+
+    def calculate_quantity(self, symbol: str, price: float, target_usdt: float) -> float:
+        """목표 USDT 기준 수량 계산"""
+        qty = target_usdt / price
+
+        if symbol in self._market_info:
+            min_qty = self._market_info[symbol]['min_qty']
+            if qty < min_qty:
+                qty = min_qty
+
+        return qty
+
+    # 시뮬레이션용 메소드들
+    async def fetch_balance(self) -> Dict[str, float]:
+        return {'USDT': 10000.0}
+
+    async def create_order(self, symbol: str, side: OrderSide, order_type: OrderType,
+                           amount: float, price: Optional[float] = None,
+                           params: Optional[Dict] = None) -> Order:
+        return Order(
+            id="sim_order_123",
+            symbol=symbol,
+            side=side,
+            type=order_type,
+            amount=amount,
+            price=price,
+            filled=amount,
+            average=price,
+            status='filled',
+            timestamp=self._get_timestamp()
+        )
+
+    async def fetch_order(self, order_id: str, symbol: str) -> Order:
+        return Order(
+            id=order_id,
+            symbol=symbol,
+            side=OrderSide.BUY,
+            type=OrderType.LIMIT,
+            amount=1.0,
+            price=100.0,
+            filled=1.0,
+            average=100.0,
+            status='filled',
+            timestamp=self._get_timestamp()
+        )
+
+    async def cancel_order(self, order_id: str, symbol: str) -> bool:
+        return True
+
+    async def fetch_positions(self) -> List[Position]:
+        return []
+
+    async def set_leverage(self, symbol: str, leverage: int) -> bool:
+        return True
+
+    async def set_margin_mode(self, symbol: str, margin_mode: str) -> bool:
+        return True

--- a/arb_trading/tests/conftest.py
+++ b/arb_trading/tests/conftest.py
@@ -1,0 +1,11 @@
+# conftest.py (pytest 설정)
+import pytest
+import asyncio
+
+
+@pytest.fixture(scope="session")
+def event_loop():
+    """세션 스코프 이벤트 루프"""
+    loop = asyncio.get_event_loop_policy().new_event_loop()
+    yield loop
+    loop.close()

--- a/arb_trading/tests/test_arbitrage.py
+++ b/arb_trading/tests/test_arbitrage.py
@@ -1,0 +1,202 @@
+# arb_trading/tests/test_arbitrage.py
+import pytest
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+from arb_trading.core.arbitrage_engine import ArbitrageEngine
+from arb_trading.core.spread_monitor import SpreadMonitor, SpreadData
+from arb_trading.core.position_manager import PositionManager, ArbitragePosition, PositionStatus
+from arb_trading.config.settings import ConfigManager
+from arb_trading.exchanges.base import Direction
+
+
+class TestArbitrageEngine:
+    """ArbitrageEngine 테스트"""
+
+    @pytest.fixture
+    def mock_config(self):
+        """목 설정 생성"""
+        config = MagicMock(spec=ConfigManager)
+
+        # trading config
+        config.trading = MagicMock()
+        config.trading.simulation_mode = True
+        config.trading.max_positions = 3
+        config.trading.target_usdt = 100
+        config.trading.spread_threshold = 0.5
+        config.trading.exit_percent = 0.5
+        config.trading.spread_hold_count = 3
+        config.trading.top_symbol_limit = 300
+        config.trading.min_volume_usdt = 5000000
+
+        # exchanges config
+        config.exchanges = {
+            'binance': MagicMock(),
+            'bybit': MagicMock()
+        }
+        config.exchanges['binance'].enabled = True
+        config.exchanges['binance'].fetch_only = False
+        config.exchanges['binance'].api_key = "test"
+        config.exchanges['binance'].secret = "test"
+        config.exchanges['bybit'].enabled = True
+        config.exchanges['bybit'].fetch_only = True
+        config.exchanges['bybit'].api_key = "test"
+        config.exchanges['bybit'].secret = "test"
+
+        # orders config
+        config.orders = MagicMock()
+        config.orders.default_type = "limit"
+        config.orders.market_order_enabled = False
+        config.orders.limit_order_slippage = 0.001
+
+        # monitoring config
+        config.monitoring = MagicMock()
+        config.monitoring.performance_logging = False
+        config.monitoring.fetch_interval = 5
+        config.monitoring.log_buffer_size = 100
+
+        # notifications config
+        config.notifications = MagicMock()
+        config.notifications.slack_webhook = ""
+        config.notifications.telegram_token = ""
+        config.notifications.telegram_chat_id = ""
+        config.notifications.email_smtp = ""
+
+        # risk config
+        config.risk = MagicMock()
+        config.risk.max_loss_percent = -10
+        config.risk.position_timeout_seconds = 300
+        config.risk.order_timeout_seconds = 60
+
+        return config
+
+    @pytest.fixture
+    def arbitrage_engine(self, mock_config):
+        """ArbitrageEngine 인스턴스 생성"""
+        return ArbitrageEngine(mock_config)
+
+    def test_initialization(self, arbitrage_engine):
+        """초기화 테스트"""
+        assert arbitrage_engine.is_running == False
+        assert arbitrage_engine.exchanges == {}
+        assert arbitrage_engine.spread_monitor is None
+        assert arbitrage_engine.position_manager is None
+
+
+class TestSpreadMonitor:
+    """SpreadMonitor 테스트"""
+
+    @pytest.fixture
+    def mock_exchanges(self):
+        """목 거래소들 생성"""
+        binance = AsyncMock()
+        binance.name = "binance"
+        binance.fetch_symbols.return_value = ["BTCUSDT", "ETHUSDT"]
+        binance.fetch_tickers.return_value = {
+            "BTCUSDT": MagicMock(last_price=50000.0),
+            "ETHUSDT": MagicMock(last_price=3000.0)
+        }
+        binance.fetch_24h_volumes.return_value = {
+            "BTCUSDT": 10000000.0,
+            "ETHUSDT": 8000000.0
+        }
+
+        bybit = AsyncMock()
+        bybit.name = "bybit"
+        bybit.fetch_symbols.return_value = ["BTCUSDT", "ETHUSDT"]
+        bybit.fetch_tickers.return_value = {
+            "BTCUSDT": MagicMock(last_price=50050.0),  # 0.1% 스프레드
+            "ETHUSDT": MagicMock(last_price=2985.0)  # 0.5% 스프레드
+        }
+        bybit.fetch_24h_volumes.return_value = {
+            "BTCUSDT": 9500000.0,
+            "ETHUSDT": 7500000.0
+        }
+
+        return {"binance": binance, "bybit": bybit}
+
+    @pytest.fixture
+    def spread_monitor(self, mock_exchanges):
+        """SpreadMonitor 인스턴스 생성"""
+        return SpreadMonitor(
+            exchanges=mock_exchanges,
+            min_volume_usdt=5000000,
+            top_symbol_limit=10
+        )
+
+    @pytest.mark.asyncio
+    async def test_get_common_symbols(self, spread_monitor):
+        """공통 심볼 조회 테스트"""
+        symbols = await spread_monitor.get_common_symbols()
+        assert "BTCUSDT" in symbols
+        assert "ETHUSDT" in symbols
+
+    @pytest.mark.asyncio
+    async def test_fetch_spread_data(self, spread_monitor):
+        """스프레드 데이터 조회 테스트"""
+        spread_data = await spread_monitor.fetch_spread_data()
+
+        assert len(spread_data) > 0
+        assert isinstance(spread_data[0], SpreadData)
+
+        # ETHUSDT가 더 큰 스프레드를 가져야 함
+        eth_spread = next((s for s in spread_data if s.symbol == "ETHUSDT"), None)
+        assert eth_spread is not None
+        assert eth_spread.abs_spread_pct > 0.4  # 약 0.5% 스프레드
+
+
+class TestPositionManager:
+    """PositionManager 테스트"""
+
+    @pytest.fixture
+    def position_manager(self):
+        """PositionManager 인스턴스 생성"""
+        return PositionManager(max_positions=3)
+
+    @pytest.fixture
+    def mock_position(self):
+        """목 포지션 생성"""
+        long_exchange = MagicMock()
+        short_exchange = MagicMock()
+
+        return ArbitragePosition(
+            symbol="BTCUSDT",
+            long_exchange=long_exchange,
+            short_exchange=short_exchange,
+            long_symbol="BTCUSDT",
+            short_symbol="BTCUSDT",
+            quantity=1.0,
+            entry_spread=0.5,
+            entry_spread_signed=0.5,
+            entry_timestamp=1234567890.0
+        )
+
+    def test_can_open_position(self, position_manager):
+        """포지션 개설 가능 여부 테스트"""
+        assert position_manager.can_open_position() == True
+
+        # 최대 개수만큼 추가
+        for i in range(3):
+            position = MagicMock()
+            position.status = PositionStatus.OPEN
+            position_manager.positions[f"TEST{i}"] = position
+
+        assert position_manager.can_open_position() == False
+
+    def test_add_position(self, position_manager, mock_position):
+        """포지션 추가 테스트"""
+        result = position_manager.add_position(mock_position)
+        assert result == True
+        assert "BTCUSDT" in position_manager.positions
+
+        # 중복 추가 시 실패해야 함
+        result = position_manager.add_position(mock_position)
+        assert result == False
+
+    def test_position_summary(self, position_manager, mock_position):
+        """포지션 요약 테스트"""
+        position_manager.add_position(mock_position)
+
+        summary = position_manager.get_position_summary()
+        assert summary["총 포지션 수"] == 1
+        assert summary["최대 포지션 수"] == 3
+        assert summary["가용 슬롯"] == 2

--- a/arb_trading/tests/test_exchanges.py
+++ b/arb_trading/tests/test_exchanges.py
@@ -1,0 +1,119 @@
+# arb_trading/tests/test_exchanges.py
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from arb_trading.exchanges.base import BaseExchange, OrderType, OrderSide, Ticker
+from arb_trading.exchanges.binance import BinanceExchange
+from arb_trading.exchanges.bybit import BybitExchange
+
+
+class TestBaseExchange:
+    """BaseExchange 테스트"""
+
+    @pytest.fixture
+    def mock_exchange(self):
+        """목 거래소 생성"""
+
+        class MockExchange(BaseExchange):
+            @property
+            def name(self):
+                return "mock"
+
+            async def fetch_tickers(self):
+                return {"BTCUSDT": Ticker("BTCUSDT", 50000.0)}
+
+            async def fetch_ticker(self, symbol):
+                return Ticker(symbol, 50000.0)
+
+            async def fetch_24h_volumes(self):
+                return {"BTCUSDT": 1000000.0}
+
+            async def fetch_symbols(self):
+                return ["BTCUSDT", "ETHUSDT"]
+
+            async def fetch_balance(self):
+                return {"USDT": 1000.0}
+
+            async def create_order(self, symbol, side, order_type, amount, price=None, params=None):
+                from arb_trading.exchanges.base import Order
+                return Order("12345", symbol, side, order_type, amount, price)
+
+            async def fetch_order(self, order_id, symbol):
+                from arb_trading.exchanges.base import Order
+                return Order(order_id, symbol, OrderSide.BUY, OrderType.LIMIT, 1.0, 50000.0)
+
+            async def cancel_order(self, order_id, symbol):
+                return True
+
+            async def fetch_positions(self):
+                return []
+
+            async def set_leverage(self, symbol, leverage):
+                return True
+
+            async def set_margin_mode(self, symbol, margin_mode):
+                return True
+
+            def normalize_symbol(self, raw_symbol):
+                return raw_symbol.upper()
+
+            def calculate_quantity(self, symbol, price, target_usdt):
+                return target_usdt / price
+
+        return MockExchange("test_key", "test_secret")
+
+    @pytest.mark.asyncio
+    async def test_connection_lifecycle(self, mock_exchange):
+        """연결 생명주기 테스트"""
+        async with mock_exchange:
+            assert mock_exchange.session is not None
+
+        # 연결 해제 후에는 session이 None이어야 함
+        assert mock_exchange.session is None
+
+    @pytest.mark.asyncio
+    async def test_fetch_tickers(self, mock_exchange):
+        """티커 조회 테스트"""
+        async with mock_exchange:
+            tickers = await mock_exchange.fetch_tickers()
+            assert "BTCUSDT" in tickers
+            assert tickers["BTCUSDT"].last_price == 50000.0
+
+
+class TestBinanceExchange:
+    """BinanceExchange 테스트"""
+
+    @pytest.fixture
+    def binance_exchange(self):
+        return BinanceExchange("test_key", "test_secret")
+
+    def test_initialization(self, binance_exchange):
+        """초기화 테스트"""
+        assert binance_exchange.name == "binance"
+
+    def test_symbol_normalization(self, binance_exchange):
+        """심볼 표준화 테스트"""
+        # 캐시가 없는 상태에서는 None 반환
+        result = binance_exchange.normalize_symbol("BTC/USDT")
+        assert result is None
+
+    def test_quantity_calculation(self, binance_exchange):
+        """수량 계산 테스트"""
+        quantity = binance_exchange.calculate_quantity("BTCUSDT", 50000.0, 1000.0)
+        assert quantity == 0.02  # 1000 / 50000
+
+
+class TestBybitExchange:
+    """BybitExchange 테스트"""
+
+    @pytest.fixture
+    def bybit_exchange(self):
+        return BybitExchange("test_key", "test_secret")
+
+    def test_initialization(self, bybit_exchange):
+        """초기화 테스트"""
+        assert bybit_exchange.name == "bybit"
+
+    def test_quantity_calculation(self, bybit_exchange):
+        """수량 계산 테스트"""
+        quantity = bybit_exchange.calculate_quantity("BTCUSDT", 50000.0, 1000.0)
+        assert quantity == 0.02  # 1000 / 50000

--- a/arb_trading/utils/__init__.py
+++ b/arb_trading/utils/__init__.py
@@ -1,0 +1,13 @@
+# arb_trading/utils/__init__.py
+"""유틸리티 모듈"""
+
+from .logger import setup_logger
+from .performance import PerformanceMonitor, PerformanceMetrics
+from .notifications import NotificationManager
+
+__all__ = [
+    'setup_logger',
+    'PerformanceMonitor',
+    'PerformanceMetrics',
+    'NotificationManager'
+]

--- a/arb_trading/utils/api_helpers.py
+++ b/arb_trading/utils/api_helpers.py
@@ -1,0 +1,91 @@
+# arb_trading/utils/api_helpers.py (새 파일)
+"""API 응답 처리 도우미 함수들"""
+
+import logging
+from typing import Any, Union, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def safe_float(value: Any, default: float = 0.0, field_name: str = "unknown") -> float:
+    """안전한 float 변환"""
+    if value is None or value == '' or value == '0':
+        return default
+
+    try:
+        result = float(value)
+        if result < 0 and default >= 0:
+            logger.warning(f"음수 값 감지 ({field_name}): {value}, 기본값 {default} 사용")
+            return default
+        return result
+    except (ValueError, TypeError) as e:
+        logger.warning(f"float 변환 실패 ({field_name}): {value} -> {e}, 기본값 {default} 사용")
+        return default
+
+
+def safe_int(value: Any, default: int = 0, field_name: str = "unknown") -> int:
+    """안전한 int 변환"""
+    if value is None or value == '':
+        return default
+
+    try:
+        return int(value)
+    except (ValueError, TypeError) as e:
+        logger.warning(f"int 변환 실패 ({field_name}): {value} -> {e}, 기본값 {default} 사용")
+        return default
+
+
+def safe_string(value: Any, default: str = "", field_name: str = "unknown") -> str:
+    """안전한 string 변환"""
+    if value is None:
+        return default
+
+    try:
+        return str(value).strip()
+    except Exception as e:
+        logger.warning(f"string 변환 실패 ({field_name}): {value} -> {e}, 기본값 '{default}' 사용")
+        return default
+
+
+def validate_ticker_data(data: dict, symbol: str) -> bool:
+    """티커 데이터 유효성 검사"""
+    required_fields = ['lastPrice']
+
+    for field in required_fields:
+        if field not in data:
+            logger.warning(f"필수 필드 누락 ({symbol}): {field}")
+            return False
+
+        if data[field] is None or data[field] == '':
+            logger.warning(f"필수 필드 비어있음 ({symbol}): {field}")
+            return False
+
+    # 가격이 0보다 큰지 확인
+    try:
+        price = float(data['lastPrice'])
+        if price <= 0:
+            logger.warning(f"유효하지 않은 가격 ({symbol}): {price}")
+            return False
+    except (ValueError, TypeError):
+        logger.warning(f"가격 파싱 실패 ({symbol}): {data['lastPrice']}")
+        return False
+
+    return True
+
+
+def filter_valid_symbols(tickers_data: list, exchange_name: str) -> list:
+    """유효한 심볼만 필터링"""
+    valid_tickers = []
+
+    for item in tickers_data:
+        symbol = item.get('symbol', '')
+        if not symbol:
+            continue
+
+        if validate_ticker_data(item, symbol):
+            valid_tickers.append(item)
+        else:
+            logger.debug(f"{exchange_name} 유효하지 않은 티커 제외: {symbol}")
+
+    logger.info(f"{exchange_name} 유효한 티커: {len(valid_tickers)}개 (전체: {len(tickers_data)}개)")
+    return valid_tickers

--- a/arb_trading/utils/logger.py
+++ b/arb_trading/utils/logger.py
@@ -1,0 +1,69 @@
+# arb_trading/utils/logger.py
+import logging
+import logging.handlers
+from pathlib import Path
+from typing import Optional
+import sys
+
+
+class ColoredFormatter(logging.Formatter):
+    """컬러 로그 포맷터"""
+
+    COLORS = {
+        'DEBUG': '\033[36m',  # 청록색
+        'INFO': '\033[32m',  # 녹색
+        'WARNING': '\033[33m',  # 노랑색
+        'ERROR': '\033[31m',  # 빨간색
+        'CRITICAL': '\033[35m',  # 자주색
+        'RESET': '\033[0m'  # 리셋
+    }
+
+    def format(self, record):
+        log_color = self.COLORS.get(record.levelname, self.COLORS['RESET'])
+        record.levelname = f"{log_color}{record.levelname}{self.COLORS['RESET']}"
+        return super().format(record)
+
+
+def setup_logger(name: str = "arb_trading",
+                 log_file: Optional[str] = None,
+                 level: str = "INFO",
+                 enable_console: bool = True) -> logging.Logger:
+    """로거 설정"""
+
+    logger = logging.getLogger(name)
+    logger.setLevel(getattr(logging, level.upper()))
+
+    # 기존 핸들러 제거
+    for handler in logger.handlers[:]:
+        logger.removeHandler(handler)
+
+    # 포맷터 설정
+    formatter = logging.Formatter(
+        '%(asctime)s - %(message)s',
+        datefmt='%Y-%m-%d %H:%M:%S'
+    )
+
+    colored_formatter = ColoredFormatter(
+        '%(asctime)s - %(message)s',
+        datefmt='%Y-%m-%d %H:%M:%S'
+    )
+
+    # 콘솔 핸들러
+    if enable_console:
+        console_handler = logging.StreamHandler(sys.stdout)
+        console_handler.setFormatter(colored_formatter)
+        logger.addHandler(console_handler)
+
+    # 파일 핸들러
+    if log_file:
+        log_path = Path(log_file)
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+
+        # 로테이팅 파일 핸들러 (최대 10MB, 5개 파일)
+        file_handler = logging.handlers.RotatingFileHandler(
+            log_file, maxBytes=10 * 1024 * 1024, backupCount=5, encoding='utf-8'
+        )
+        file_handler.setFormatter(formatter)
+        logger.addHandler(file_handler)
+
+    return logger

--- a/arb_trading/utils/notifications.py
+++ b/arb_trading/utils/notifications.py
@@ -1,0 +1,130 @@
+# arb_trading/utils/notifications.py
+import asyncio
+import aiohttp
+import smtplib
+from email.mime.text import MIMEText
+from email.mime.multipart import MIMEMultipart
+from typing import Optional, Dict
+import json
+
+
+class NotificationManager:
+    """알림 관리 클래스"""
+
+    def __init__(self, slack_webhook: str = "", telegram_token: str = "",
+                 telegram_chat_id: str = "", email_config: Optional[Dict] = None):
+        self.slack_webhook = slack_webhook
+        self.telegram_token = telegram_token
+        self.telegram_chat_id = telegram_chat_id
+        self.email_config = email_config or {}
+
+    async def send_slack_notification(self, message: str, level: str = "INFO"):
+        """슬랙 알림 발송"""
+        if not self.slack_webhook:
+            return
+
+        try:
+            color_map = {
+                "INFO": "#36a64f",  # 녹색
+                "WARNING": "#ff9500",  # 주황색
+                "ERROR": "#ff0000",  # 빨간색
+                "CRITICAL": "#8b0000"  # 진한 빨간색
+            }
+
+            payload = {
+                "attachments": [{
+                    "color": color_map.get(level, "#36a64f"),
+                    "fields": [{
+                        "title": f"차익거래 시스템 - {level}",
+                        "value": message,
+                        "short": False
+                    }],
+                    "ts": asyncio.get_event_loop().time()
+                }]
+            }
+
+            async with aiohttp.ClientSession() as session:
+                async with session.post(self.slack_webhook, json=payload) as response:
+                    if response.status != 200:
+                        print(f"슬랙 알림 발송 실패: {response.status}")
+
+        except Exception as e:
+            print(f"슬랙 알림 발송 중 오류: {e}")
+
+    async def send_telegram_notification(self, message: str):
+        """텔레그램 알림 발송"""
+        if not self.telegram_token or not self.telegram_chat_id:
+            return
+
+        try:
+            url = f"https://api.telegram.org/bot{self.telegram_token}/sendMessage"
+            payload = {
+                "chat_id": self.telegram_chat_id,
+                "text": f"🤖 차익거래 시스템\n\n{message}",
+                "parse_mode": "Markdown"
+            }
+
+            async with aiohttp.ClientSession() as session:
+                async with session.post(url, json=payload) as response:
+                    if response.status != 200:
+                        print(f"텔레그램 알림 발송 실패: {response.status}")
+
+        except Exception as e:
+            print(f"텔레그램 알림 발송 중 오류: {e}")
+
+    def send_email_notification(self, subject: str, message: str):
+        """이메일 알림 발송 (동기)"""
+        if not self.email_config.get('smtp_server'):
+            return
+
+        try:
+            msg = MIMEMultipart()
+            msg['From'] = self.email_config['user']
+            msg['To'] = self.email_config.get('to_email', self.email_config['user'])
+            msg['Subject'] = f"차익거래 시스템 - {subject}"
+
+            body = f"""
+            차익거래 시스템에서 알림이 발생했습니다.
+
+            {message}
+
+            시간: {asyncio.get_event_loop().time()}
+            """
+
+            msg.attach(MIMEText(body, 'plain', 'utf-8'))
+
+            server = smtplib.SMTP(self.email_config['smtp_server'],
+                                  self.email_config.get('smtp_port', 587))
+            server.starttls()
+            server.login(self.email_config['user'], self.email_config['password'])
+
+            text = msg.as_string()
+            server.sendmail(self.email_config['user'],
+                            self.email_config.get('to_email', self.email_config['user']),
+                            text)
+            server.quit()
+
+        except Exception as e:
+            print(f"이메일 알림 발송 중 오류: {e}")
+
+    async def notify_all(self, message: str, level: str = "INFO", include_email: bool = False):
+        """모든 채널로 알림 발송"""
+        tasks = []
+
+        if self.slack_webhook:
+            tasks.append(self.send_slack_notification(message, level))
+
+        if self.telegram_token and self.telegram_chat_id:
+            tasks.append(self.send_telegram_notification(message))
+
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+        if include_email and self.email_config.get('smtp_server'):
+            # 이메일은 별도 스레드에서 실행
+            import threading
+            threading.Thread(
+                target=self.send_email_notification,
+                args=(level, message),
+                daemon=True
+            ).start()

--- a/arb_trading/utils/performance.py
+++ b/arb_trading/utils/performance.py
@@ -1,0 +1,242 @@
+# arb_trading/utils/performance.py (상세 로깅 추가)
+import time
+import psutil
+import threading
+import os
+from typing import Dict, Any, Optional, List
+from dataclasses import dataclass, field
+from collections import defaultdict, deque
+import logging
+
+
+@dataclass
+class PerformanceMetrics:
+    """성능 메트릭 데이터"""
+    # 전체 처리 시간
+    fetch_times: deque = field(default_factory=lambda: deque(maxlen=100))
+    spread_calc_times: deque = field(default_factory=lambda: deque(maxlen=100))
+
+    # 거래소별 세부 시간
+    exchange_fetch_times: Dict[str, deque] = field(default_factory=lambda: defaultdict(lambda: deque(maxlen=100)))
+
+    # API 호출 통계
+    api_call_counts: Dict[str, int] = field(default_factory=lambda: defaultdict(int))
+    error_counts: Dict[str, int] = field(default_factory=lambda: defaultdict(int))
+
+    # 프로세스별 리소스 사용량
+    process_cpu_usage: deque = field(default_factory=lambda: deque(maxlen=50))
+    process_memory_usage: deque = field(default_factory=lambda: deque(maxlen=50))
+    process_memory_mb: deque = field(default_factory=lambda: deque(maxlen=50))
+
+
+@dataclass
+class FetchTiming:
+    """개별 Fetch 타이밍 정보"""
+    exchange: str
+    operation: str  # 'tickers', 'volumes', 'symbols'
+    duration: float
+    timestamp: float
+    success: bool
+    error_msg: str = ""
+
+
+class PerformanceMonitor:
+    """성능 모니터링 클래스"""
+
+    def __init__(self, enabled: bool = False):
+        self.enabled = enabled
+        self.metrics = PerformanceMetrics()
+        self._start_time = time.time()
+        self._monitoring_thread: Optional[threading.Thread] = None
+        self._stop_monitoring = threading.Event()
+        self._process = None
+        self.logger = logging.getLogger(__name__)
+
+        # 상세 로깅용
+        self._current_fetch_timings: List[FetchTiming] = []
+
+        if self.enabled:
+            try:
+                self._process = psutil.Process(os.getpid())
+                self.start_process_monitoring()
+                self.logger.info("성능 모니터링 시작 (상세 로깅 활성화)")
+            except Exception as e:
+                self.logger.warning(f"프로세스 모니터링 초기화 실패: {e}")
+
+    def start_process_monitoring(self):
+        """프로세스 리소스 모니터링 시작"""
+
+        def monitor():
+            while not self._stop_monitoring.is_set():
+                try:
+                    if self._process and self._process.is_running():
+                        cpu_percent = self._process.cpu_percent(interval=0.1)
+                        self.metrics.process_cpu_usage.append(cpu_percent)
+
+                        memory_info = self._process.memory_info()
+                        memory_mb = memory_info.rss / 1024 / 1024
+                        total_memory = psutil.virtual_memory().total
+                        memory_percent = (memory_info.rss / total_memory) * 100
+
+                        self.metrics.process_memory_usage.append(memory_percent)
+                        self.metrics.process_memory_mb.append(memory_mb)
+
+                    time.sleep(2)
+
+                except (psutil.NoSuchProcess, psutil.AccessDenied):
+                    break
+                except Exception:
+                    time.sleep(1)
+
+        self._monitoring_thread = threading.Thread(target=monitor, daemon=True)
+        self._monitoring_thread.start()
+
+    def stop_monitoring(self):
+        """모니터링 중지"""
+        self._stop_monitoring.set()
+        if self._monitoring_thread:
+            self._monitoring_thread.join(timeout=2)
+
+    def start_fetch_cycle(self):
+        """Fetch 사이클 시작 (타이밍 초기화)"""
+        if self.enabled:
+            self._current_fetch_timings.clear()
+
+    def record_exchange_fetch(self, exchange: str, operation: str, duration: float,
+                              success: bool = True, error_msg: str = ""):
+        """거래소별 fetch 시간 기록"""
+        if self.enabled:
+            # 상세 타이밍 정보 저장
+            timing = FetchTiming(
+                exchange=exchange,
+                operation=operation,
+                duration=duration,
+                timestamp=time.time(),
+                success=success,
+                error_msg=error_msg
+            )
+            self._current_fetch_timings.append(timing)
+
+            # 거래소별 시간 저장
+            self.metrics.exchange_fetch_times[exchange].append(duration)
+
+            # 상세 로깅
+            status = "✅" if success else "❌"
+            self.logger.info(
+                f"📊 {status} {exchange.upper()} {operation}: {duration:.3f}초"
+                f"{f' (오류: {error_msg})' if error_msg else ''}"
+            )
+
+    def record_fetch_time(self, duration: float):
+        """전체 데이터 페치 시간 기록"""
+        if self.enabled:
+            self.metrics.fetch_times.append(duration)
+
+            # 거래소별 상세 로깅
+            if self._current_fetch_timings:
+                self.logger.info(f"🔄 전체 데이터 페치 완료: {duration:.3f}초")
+
+                # 거래소별 분석
+                exchange_summary = defaultdict(list)
+                for timing in self._current_fetch_timings:
+                    exchange_summary[timing.exchange].append(timing.duration)
+
+                for exchange, durations in exchange_summary.items():
+                    total_time = sum(durations)
+                    avg_time = total_time / len(durations)
+                    self.logger.info(
+                        f"  📈 {exchange.upper()}: {total_time:.3f}초 "
+                        f"(평균: {avg_time:.3f}초, 호출: {len(durations)}회)"
+                    )
+
+    def record_spread_calc_time(self, duration: float, symbols_count: int = 0):
+        """스프레드 계산 시간 기록"""
+        if self.enabled:
+            self.metrics.spread_calc_times.append(duration)
+
+            # 상세 로깅
+            if symbols_count > 0:
+                per_symbol = duration / symbols_count * 1000  # ms per symbol
+                self.logger.info(
+                    f"⚡ 스프레드 계산 완료: {duration:.3f}초 "
+                    f"({symbols_count}개 심볼, 심볼당 {per_symbol:.1f}ms)"
+                )
+            else:
+                self.logger.info(f"⚡ 스프레드 계산 완료: {duration:.3f}초")
+
+    def record_total_cycle_time(self, total_duration: float, fetch_duration: float,
+                                calc_duration: float, symbols_processed: int):
+        """전체 사이클 시간 기록 및 상세 로깅"""
+        if self.enabled:
+            overhead = total_duration - fetch_duration - calc_duration
+
+            self.logger.info("=" * 60)
+            self.logger.info(f"🎯 스프레드 모니터링 사이클 완료")
+            self.logger.info(f"   전체 시간: {total_duration:.3f}초")
+            self.logger.info(f"   ├─ 데이터 페치: {fetch_duration:.3f}초 ({fetch_duration / total_duration * 100:.1f}%)")
+            self.logger.info(f"   ├─ 스프레드 계산: {calc_duration:.3f}초 ({calc_duration / total_duration * 100:.1f}%)")
+            self.logger.info(f"   └─ 기타 처리: {overhead:.3f}초 ({overhead / total_duration * 100:.1f}%)")
+            self.logger.info(f"   처리된 심볼: {symbols_processed}개")
+
+            if symbols_processed > 0:
+                throughput = symbols_processed / total_duration
+                self.logger.info(f"   처리 성능: {throughput:.1f} 심볼/초")
+
+            self.logger.info("=" * 60)
+
+    def record_api_call(self, exchange: str):
+        """API 호출 횟수 기록"""
+        if self.enabled:
+            self.metrics.api_call_counts[exchange] += 1
+
+    def record_error(self, error_type: str):
+        """에러 발생 기록"""
+        if self.enabled:
+            self.metrics.error_counts[error_type] += 1
+
+    def get_exchange_performance_summary(self) -> Dict[str, Any]:
+        """거래소별 성능 요약"""
+        if not self.enabled:
+            return {}
+
+        summary = {}
+        for exchange, times in self.metrics.exchange_fetch_times.items():
+            if times:
+                summary[exchange] = {
+                    "평균 응답시간": f"{sum(times) / len(times):.3f}초",
+                    "최근 10회 평균": f"{sum(list(times)[-10:]) / min(10, len(times)):.3f}초",
+                    "최소 시간": f"{min(times):.3f}초",
+                    "최대 시간": f"{max(times):.3f}초",
+                    "총 호출 횟수": len(times)
+                }
+
+        return summary
+
+    def get_performance_summary(self) -> Dict[str, Any]:
+        """성능 요약 정보 반환"""
+        if not self.enabled:
+            return {"성능 모니터링": "비활성화됨"}
+
+        summary = {
+            # "실행 시간": f"{time.time() - self._start_time:.1f}초",
+            "전체 성능": {
+                "데이터 페치 평균": f"{sum(self.metrics.fetch_times) / len(self.metrics.fetch_times):.3f}초" if self.metrics.fetch_times else "N/A",
+                # "스프레드 계산 평균": f"{sum(self.metrics.spread_calc_times) / len(self.metrics.spread_calc_times):.3f}초" if self.metrics.spread_calc_times else "N/A",
+                # "총 사이클 수": len(self.metrics.fetch_times)
+            },
+            "거래소별 성능": self.get_exchange_performance_summary(),
+            # "API 호출 통계": dict(self.metrics.api_call_counts),
+            "에러 발생 통계": dict(self.metrics.error_counts)
+        }
+
+        # 프로세스 리소스 정보
+        if self.metrics.process_cpu_usage and self.metrics.process_memory_mb:
+            avg_cpu = sum(self.metrics.process_cpu_usage) / len(self.metrics.process_cpu_usage)
+            current_memory = self.metrics.process_memory_mb[-1] if self.metrics.process_memory_mb else 0
+
+            summary["프로세스 리소스"] = {
+                "평균 CPU": f"{avg_cpu:.1f}%",
+                "현재 메모리": f"{current_memory:.1f} MB"
+            }
+
+        return summary

--- a/arb_trading/utils/platform_utils.py
+++ b/arb_trading/utils/platform_utils.py
@@ -1,0 +1,52 @@
+# arb_trading/utils/platform_utils.py
+import asyncio
+import sys
+import platform
+import logging
+
+
+def setup_windows_event_loop():
+    """Windows 환경에서 이벤트 루프 설정"""
+    if platform.system() == 'Windows':
+        # Windows에서 SelectorEventLoop 사용
+        if sys.version_info >= (3, 8):
+            # Python 3.8+에서는 ProactorEventLoop가 기본이므로 SelectorEventLoop로 변경
+            asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+        else:
+            # Python 3.7 이하에서는 SelectorEventLoop가 기본
+            loop = asyncio.SelectorEventLoop()
+            asyncio.set_event_loop(loop)
+
+
+def get_optimal_connector():
+    """플랫폼에 최적화된 aiohttp 커넥터 반환"""
+    import aiohttp
+
+    if platform.system() == 'Windows':
+        # Windows에서는 기본 커넥터 사용 (DNS 해상도 문제 방지)
+        return aiohttp.TCPConnector(
+            limit=100,
+            limit_per_host=10,
+            ttl_dns_cache=300,
+            use_dns_cache=True,
+            enable_cleanup_closed=True
+        )
+    else:
+        # Linux/Mac에서는 성능 최적화된 커넥터
+        try:
+            import aiohttp_speedups  # 선택적 성능 향상
+            return aiohttp.TCPConnector(
+                limit=100,
+                limit_per_host=20,
+                ttl_dns_cache=300,
+                use_dns_cache=True,
+                enable_cleanup_closed=True
+            )
+        except ImportError:
+            return aiohttp.TCPConnector(
+                limit=100,
+                limit_per_host=10,
+                ttl_dns_cache=300,
+                use_dns_cache=True,
+                enable_cleanup_closed=True
+            )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,9 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
 [project]
-name = "arbitrage-trading"
+name = "crypto-arbitrage-trading"
 version = "0.1.0"
 description = "암호화폐 거래소 간 스프레드 모니터링 대시보드"
 authors = [
@@ -16,10 +20,6 @@ dependencies = [
 requires-python = ">=3.10"
 readme = "README.md"
 license = { text = "MIT" }
-
-[build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
 
 [tool.hatch.metadata]
 allow-direct-references = true


### PR DESCRIPTION
Claude 와 함께 작업한 결과임. 

1. https://github.com/FinAI6/arbitrage-trading/blob/main/trading/arb_trading_maker.py 의 개선 버전
2. https://ahead-cardigan-c4d.notion.site/Arb-2157713187b68045ad11ca5364840d0e 의 개선 포인트 반영
3. 기존 arb_trading_maker.py 의 경우 평균 700ms 정도의 fetch & spread 계산 시간이 필요했다면, 해당 변경의 경우 async 기법을 적용하여 약 350ms 정도의 fetch & spread 계산 시간이 소요됨.

다만 아직 이걸로 실제 거래를 해보진 못 했음.

# 실행 방법
```
python -m arb_trading 
```
혹은 `arb_trading/__main__.py` 실행.
